### PR TITLE
Неявная конвертация int в double

### DIFF
--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/labeling/RaoLabelProvider.xtend
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/labeling/RaoLabelProvider.xtend
@@ -9,7 +9,7 @@ import static extension ru.bmstu.rk9.rao.generator.RaoNaming.*
 import ru.bmstu.rk9.rao.rao.RaoModel
 
 import ru.bmstu.rk9.rao.rao.ResourceType
-import ru.bmstu.rk9.rao.rao.ParameterType
+import ru.bmstu.rk9.rao.rao.Parameter
 
 import ru.bmstu.rk9.rao.rao.ResourceCreateStatement
 
@@ -60,8 +60,8 @@ class RaoLabelProvider extends org.eclipse.xtext.ui.label.DefaultEObjectLabelPro
 	def image(ResourceType rtp) { "puzzle_plus.gif" }
 
 	// Parameter types
-	def  text(ParameterType p) { p.name + p.typeGenericLabel }
-	def image(ParameterType p) { "parameter.gif" }
+	def  text(Parameter p) { p.name + p.typeGenericLabel }
+	def image(Parameter p) { "parameter.gif" }
 
 	// Resource declaration
 	def  text(ResourceCreateStatement rss) { "rss : " + rss.name }

--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/labeling/RaoLabelProvider.xtend
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/labeling/RaoLabelProvider.xtend
@@ -48,57 +48,63 @@ class RaoLabelProvider extends org.eclipse.xtext.ui.label.DefaultEObjectLabelPro
 		super(delegate);
 	}
 
-	// Model
-	def image(RaoModel m) { "model.gif" }
+	def image(RaoModel model) { "model.gif" }
 
-	// Default methods
-	def text(DefaultMethod dm) { "set : " + dm.name }
-	def image(DefaultMethod dm) { "run.gif" }
+	def text(DefaultMethod defaultMethod) { "set : " + defaultMethod.name }
 
-	// Resource types
-	def  text(ResourceType rtp) { "RTP : " + rtp.name }
-	def image(ResourceType rtp) { "puzzle_plus.gif" }
+	def image(DefaultMethod defaultMethod) { "run.gif" }
 
-	// Parameter types
-	def  text(Parameter p) { p.name + p.typeGenericLabel }
-	def image(Parameter p) { "parameter.gif" }
+	def text(ResourceType resourceType) { "resource type : " + resourceType.name }
 
-	// Resource declaration
-	def  text(ResourceCreateStatement rss) { "rss : " + rss.name }
-	def image(ResourceCreateStatement rss) { "plus.gif" }
+	def image(ResourceType resourceType) { "puzzle_plus.gif" }
 
-	// Constants
-	def image(Constant c) { "constant2.gif" }
-	def  text(Constant c) { c.name + c.type.typeGenericLabel }
+	def text(Parameter parameter) { parameter.name + parameter.typeGenericLabel }
 
-	// Sequence
-	def  text(Sequence seq) { "SEQ : " + seq.name + " : " + (
-		if(seq.type instanceof EnumerativeSequence) "enumerative" else "" +
-		if(seq.type instanceof RegularSequence) (seq.type as RegularSequence).type else "" +
-		if(seq.type instanceof HistogramSequence) "histogram" else "" ) + seq.returnType.typeGenericLabel }
-	def image(Sequence seq) { "chart.gif" }
+	def image(Parameter parameter) { "parameter.gif" }
 
-	// Function
-	def  text(Function fun) { "FUN : " + fun.type.name + fun.returnType.typeGenericLabel }
-	def image(Function fun) { "calc_arrow.gif" }
+	def text(ResourceCreateStatement resource) { "resource : " + resource.name }
 
-	def image(FunctionParameter p) { "parameter.gif" }
-	def  text(FunctionParameter p) { p.name + p.type.typeGenericLabel }
+	def image(ResourceCreateStatement resource) { "plus.gif" }
 
-	// Event
-	def  text(Event evn) { "EVN : " + evn.name + " : event"}
-	def image(Event evn) { "event.gif" }
+	def text(Constant constant) { constant.name + constant.type.typeGenericLabel }
 
-	// Operation
-	def  text(Pattern pat) { "PAT : " + pat.name + " : " + pat.type.literal}
-	def image(Pattern pat) { "script_block.gif" }
+	def image(Constant constant) { "constant2.gif" }
 
-	// Common for patterns
+	def text(Sequence sequence) {
+		"sequence : " + sequence.name + " : " + (
+		if (sequence.type instanceof EnumerativeSequence)
+			"enumerative"
+		else
+			"" + if (sequence.type instanceof RegularSequence)
+				(sequence.type as RegularSequence).type
+			else
+				"" + if(sequence.type instanceof HistogramSequence) "histogram" else "" ) +
+			sequence.returnType.typeGenericLabel
+	}
 
-	def image(RelevantResource r) { "parameter.gif" }
-	def  text(RelevantResource r) { r.name + r.type.relResName }
+	def image(Sequence sequence) { "chart.gif" }
 
-	def getRelResName(EObject object) {
+	def text(Function function) { "function : " + function.type.name + function.returnType.typeGenericLabel }
+
+	def image(Function function) { "calc_arrow.gif" }
+
+	def image(FunctionParameter parameter) { "parameter.gif" }
+
+	def text(FunctionParameter parameter) { parameter.name + parameter.type.typeGenericLabel }
+
+	def text(Event event) { "event : " + event.name + " : event" }
+
+	def image(Event event) { "event.gif" }
+
+	def text(Pattern pattern) { "pattern : " + pattern.name + " : " + pattern.type.literal }
+
+	def image(Pattern pattern) { "script_block.gif" }
+
+	def image(RelevantResource relevantResource) { "parameter.gif" }
+
+	def text(RelevantResource relevantResource) { relevantResource.name + relevantResource.type.relevantResourceName }
+
+	def getRelevantResourceName(EObject object) {
 		switch object {
 			ResourceType: " : RTP : " + object.name
 			ResourceCreateStatement: " : RSS : " + object.name
@@ -106,28 +112,29 @@ class RaoLabelProvider extends org.eclipse.xtext.ui.label.DefaultEObjectLabelPro
 		}
 	}
 
-	// Decision points
-	def image(DecisionPointSearchActivity d) { "script_block.gif" }
-	def image(DecisionPointActivity d) { "script_block.gif" }
+	def image(DecisionPointSearchActivity activity) { "script_block.gif" }
 
-	// DecisionPointSome
-	def  text(DecisionPointSome dpt) { "DPT : " + dpt.name + " : some" }
-	def image(DecisionPointSome dpt) { "block.gif" }
+	def image(DecisionPointActivity activity) { "script_block.gif" }
 
-	// DecisionPointSearch
-	def  text(DecisionPointSearch dpt) {"DPT : " + dpt.name + " : search" }
-	def image(DecisionPointSearch dpt) { "search.gif" }
+	def text(DecisionPointSome decisionPoint) { "decision point : " + decisionPoint.name + " : some" }
 
-	// Results
-	def  text(Result d) { d.name + " : " + resultype(d)}
+	def image(DecisionPointSome decisionPoint) { "block.gif" }
+
+	def text(DecisionPointSearch search) { "search : " + search.name + " : search" }
+
+	def image(DecisionPointSearch search) { "search.gif" }
+
+	def text(Result result) { result.name + " : " + resultype(result) }
+
 	def resultype(Result declaration) {
 		switch declaration.type {
-			ResultWatchParameter: "watchPar"
-			ResultWatchState    : "watchState"
-			ResultWatchQuant    : "watchQuant"
-			ResultWatchValue    : "watchValue"
-			ResultGetValue      : "getValue"
+			ResultWatchParameter: "watchParameter"
+			ResultWatchState: "watchState"
+			ResultWatchQuant: "watchQuant"
+			ResultWatchValue: "watchValue"
+			ResultGetValue: "getValue"
 		}
 	}
-	def image(Result d) { "parameter.gif" }
+
+	def image(Result result) { "parameter.gif" }
 }

--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/outline/RaoOutlineTreeProvider.xtend
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/outline/RaoOutlineTreeProvider.xtend
@@ -5,7 +5,7 @@ import org.eclipse.swt.graphics.Image
 import org.eclipse.xtext.ui.editor.outline.impl.AbstractOutlineNode
 import org.eclipse.xtext.ui.editor.outline.IOutlineNode
 
-import ru.bmstu.rk9.rao.rao.ParameterType
+import ru.bmstu.rk9.rao.rao.Parameter
 
 import ru.bmstu.rk9.rao.rao.ResourceCreateStatement
 
@@ -36,12 +36,12 @@ class RaoOutlineTreeProvider extends org.eclipse.xtext.ui.editor.outline.impl.De
 
 	// Resource Types
 	def _createChildren(IOutlineNode parentNode, ResourceType resourceType) {
-		for (parameterType : resourceType.eAllContents.toIterable.filter(typeof(ParameterType))) {
-			createNode(parentNode, parameterType)
+		for (parameter : resourceType.eAllContents.toIterable.filter(typeof(Parameter))) {
+			createNode(parentNode, parameter)
 		}
 	}
 
-	def _isLeaf(ParameterType parameterType) { true }
+	def _isLeaf(Parameter parameter) { true }
 
 	// Resources
 	def _isLeaf(ResourceCreateStatement resourceCreateStatement) { true }
@@ -63,10 +63,10 @@ class RaoOutlineTreeProvider extends org.eclipse.xtext.ui.editor.outline.impl.De
 
 	// Pattern
 	def _createChildren(IOutlineNode parentNode, Pattern pattern) {
-		if (!pattern.eAllContents.filter(typeof(ParameterType)).empty) {
+		if (!pattern.eAllContents.filter(typeof(Parameter)).empty) {
 			val groupParameters = new VirtualOutlineNode(parentNode, parentNode.image, "Parameters", false)
-			for (parameterType : pattern.eAllContents.toIterable.filter(typeof(ParameterType))) {
-				createEObjectNode(groupParameters, parameterType)
+			for (parameter : pattern.eAllContents.toIterable.filter(typeof(Parameter))) {
+				createEObjectNode(groupParameters, parameter)
 			}
 		}
 

--- a/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/Rao.xtext
+++ b/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/Rao.xtext
@@ -33,27 +33,12 @@ RaoEntity
 
 ResourceType:
 	'type' name = ID '{'
-		(parameters += ParameterType ';' )+
+		(parameters += Parameter ';' )+
 	'}'
 ;
 
-ParameterType
-	: ParameterTypeBasic
-	| ParameterTypeString
-	| ParameterTypeArray
-;
-
-ParameterTypeBasic:
-	type = (RaoInt | RaoDouble | RaoBoolean | RaoEnum) name = ID
-		('=' default = ExpressionOr)?
-;
-
-ParameterTypeString:
-	type = RaoString name = ID ('=' default = STRING)?
-;
-
-ParameterTypeArray:
-	type = RaoArray name = ID ('=' default = ArrayValues)?
+Parameter
+	: type = RaoType name = ID ('=' default = ExpressionOr)?
 ;
 
 // ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― //
@@ -75,8 +60,8 @@ ResourceParameterExpression
 
 Event:
 	'event' name = ID '('
-		(parameters += ParameterType (
-			',' parameters += ParameterType)* )? ')' '{'
+		(parameters += Parameter (
+			',' parameters += Parameter)* )? ')' '{'
 		body = StatementList
 	'}'
 ;
@@ -87,8 +72,8 @@ Event:
 
 Pattern:
 	type = PatternType name = ID '('
-		(parameters += ParameterType (
-			',' parameters += ParameterType)* )? ')' '{'
+		(parameters += Parameter (
+			',' parameters += Parameter)* )? ')' '{'
 		relevantResources += RelevantResource*
 		('relevantSet' combinational = PatternSelectMethod ';')?
 		defaultMethods += DefaultMethod*

--- a/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/RaoLinkingDiagnosticMessageProvider.java
+++ b/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/RaoLinkingDiagnosticMessageProvider.java
@@ -6,7 +6,7 @@ import org.eclipse.xtext.diagnostics.Severity;
 import org.eclipse.xtext.diagnostics.DiagnosticMessage;
 import org.eclipse.xtext.linking.impl.LinkingDiagnosticMessageProvider;
 
-import ru.bmstu.rk9.rao.rao.ParameterType;
+import ru.bmstu.rk9.rao.rao.Parameter;
 import ru.bmstu.rk9.rao.rao.ResourceType;
 
 public class RaoLinkingDiagnosticMessageProvider extends
@@ -36,7 +36,7 @@ public class RaoLinkingDiagnosticMessageProvider extends
 			break;
 
 		case "EnumID":
-			ParameterType parent = (ParameterType) context
+			Parameter parent = (Parameter) context
 					.getContext().eContainer();
 			ResourceType grandparent = (ResourceType) parent.eContainer();
 			msg = "Value '" + context.getLinkText()

--- a/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/compilers/EventCompiler.xtend
+++ b/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/compilers/EventCompiler.xtend
@@ -3,11 +3,10 @@ package ru.bmstu.rk9.rao.compilers
 import static extension ru.bmstu.rk9.rao.generator.RaoNaming.*
 import static extension ru.bmstu.rk9.rao.generator.RaoExpressionCompiler.*
 import static extension ru.bmstu.rk9.rao.generator.RaoStatementCompiler.*
-import static extension ru.bmstu.rk9.rao.compilers.ResourceTypeCompiler.*
 import static extension ru.bmstu.rk9.rao.compilers.PatternCompiler.*
 
 import ru.bmstu.rk9.rao.rao.Event
-import ru.bmstu.rk9.rao.rao.ParameterType
+import ru.bmstu.rk9.rao.rao.Parameter
 import java.util.List
 
 class EventCompiler
@@ -92,7 +91,7 @@ class EventCompiler
 		'''
 	}
 
-	def private static compileParameterTypesCall(List<ParameterType> parameters)
+	def private static compileParameterTypesCall(List<Parameter> parameters)
 	{
 		'''«IF !parameters.empty»«
 			parameters.get(0).name»«

--- a/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/compilers/FunctionCompiler.xtend
+++ b/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/compilers/FunctionCompiler.xtend
@@ -36,6 +36,8 @@ class FunctionCompiler
 		package «filename»;
 
 		import ru.bmstu.rk9.rao.lib.*;
+		import ru.bmstu.rk9.rao.lib.simulator.*;
+		import ru.bmstu.rk9.rao.lib.database.*;
 		@SuppressWarnings("all")
 
 		public class «function.type.name»

--- a/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/compilers/PatternCompiler.xtend
+++ b/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/compilers/PatternCompiler.xtend
@@ -7,7 +7,6 @@ import org.eclipse.emf.ecore.EObject
 import static extension ru.bmstu.rk9.rao.generator.RaoNaming.*
 import static extension ru.bmstu.rk9.rao.generator.RaoExpressionCompiler.*
 import static extension ru.bmstu.rk9.rao.generator.RaoStatementCompiler.*
-import static extension ru.bmstu.rk9.rao.compilers.ResourceTypeCompiler.*
 
 import ru.bmstu.rk9.rao.generator.LocalContext
 
@@ -16,7 +15,7 @@ import ru.bmstu.rk9.rao.rao.ResourceType
 import ru.bmstu.rk9.rao.rao.ResourceCreateStatement
 
 import ru.bmstu.rk9.rao.rao.Pattern
-import ru.bmstu.rk9.rao.rao.ParameterType
+import ru.bmstu.rk9.rao.rao.Parameter
 import ru.bmstu.rk9.rao.rao.PatternSelectMethod
 import ru.bmstu.rk9.rao.rao.RelevantResource
 import ru.bmstu.rk9.rao.rao.PatternSelectLogic
@@ -525,7 +524,7 @@ class PatternCompiler
 		}
 	}
 
-	def static compileParameterTypes(List<ParameterType> parameters)
+	def static compileParameterTypes(List<Parameter> parameters)
 	{
 		'''«IF !parameters.empty»«parameters.get(0).compileType» «
 			parameters.get(0).name»«

--- a/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/compilers/ResourceTypeCompiler.xtend
+++ b/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/compilers/ResourceTypeCompiler.xtend
@@ -9,10 +9,7 @@ import static extension ru.bmstu.rk9.rao.generator.RaoExpressionCompiler.*
 import static extension ru.bmstu.rk9.rao.compilers.EnumCompiler.*
 
 import ru.bmstu.rk9.rao.rao.ResourceType
-import ru.bmstu.rk9.rao.rao.ParameterType
-import ru.bmstu.rk9.rao.rao.ParameterTypeBasic
-import ru.bmstu.rk9.rao.rao.ParameterTypeString
-import ru.bmstu.rk9.rao.rao.ParameterTypeArray
+import ru.bmstu.rk9.rao.rao.Parameter
 
 import ru.bmstu.rk9.rao.rao.ResourceCreateStatement
 
@@ -242,7 +239,7 @@ class ResourceTypeCompiler
 		'''
 	}
 
-	def private static compileParameterTypesCopyCall(List<ParameterType> parameters)
+	def private static compileParameterTypesCopyCall(List<Parameter> parameters)
 	{
 		'''«IF parameters.size > 0»«
 			parameters.get(0).name»«
@@ -361,7 +358,7 @@ class ResourceTypeCompiler
 
 	}
 
-	def private static String compileBufferCalculation(Iterable<ParameterType> parameters)
+	def private static String compileBufferCalculation(Iterable<Parameter> parameters)
 	{
 		var ret = ""
 
@@ -423,7 +420,7 @@ class ResourceTypeCompiler
 		return ret
 	}
 
-	def private static String compileSerialization(Iterable<ParameterType> parameters)
+	def private static String compileSerialization(Iterable<Parameter> parameters)
 	{
 		var ret = ""
 		val constantSizeParameters = parameters.filter
@@ -568,72 +565,53 @@ class ResourceTypeCompiler
 		return '''«FOR i : 0 ..< number»	«ENDFOR»'''
 	}
 
-	def private static int getArrayDepth(ParameterType parameter)
+	def private static int getArrayDepth(Parameter parameter)
 	{
 		var EObject type = parameter
 		var depth = 0;
 
-		while (type instanceof ParameterTypeArray || type instanceof RaoArray)
+		while (type instanceof RaoArray)
 		{
-			if (type instanceof ParameterTypeArray)
-				type = (type as ParameterTypeArray).type.arrayType
-			else
-				type = (type as RaoArray).arrayType
+			type = (type as RaoArray).arrayType
 			depth = depth + 1
 		}
 
 		return depth
 	}
 
-	def private static String getArrayType(ParameterType parameter)
+	def private static String getArrayType(Parameter parameter)
 	{
 		var EObject type = parameter
 
-		while (type instanceof ParameterTypeArray || type instanceof RaoArray)
-			if (type instanceof ParameterTypeArray)
-				type = (type as ParameterTypeArray).type.arrayType
-			else
-				type = (type as RaoArray).arrayType
+		while (type instanceof RaoArray)
+			type = (type as RaoArray).arrayType
 
-		type.getTypename
+		type.compileTypePrimitive
 	}
 
-	def private static String getTypename(EObject type)
+	def static String getDefault(Parameter parameter)
 	{
-		switch (type)
+		switch parameter.type
 		{
-			RaoInt : return "integer"
-			RaoDouble : return "real"
-			RaoBoolean : return "boolean"
-			RaoEnum : return type.compileType
-			RaoString : return "string"
-			default: return null
-		}
-	}
+			RaoInt,
+			RaoDouble,
+			RaoBoolean: {
+				if (parameter.^default == null)
+					return ""
 
-	def static String getDefault(ParameterType parameter)
-	{
-		switch parameter
-		{
-			ParameterTypeBasic: {
-				var defaultValue = ""
-				if (parameter.^default != null) {
-					if (parameter.type instanceof RaoEnum) {
-						val value = parameter.^default.compileExpression.value
-						val fullTypeName = (parameter.type as RaoEnum).getFullEnumName
-						if (checkValidEnumID(
-								(parameter.type as RaoEnum).getFullEnumName,
-								value))
-							defaultValue = " = " + compileEnumValue(fullTypeName, value)
-					}
-					else
-						defaultValue = " = " + parameter.^default.compileExpression.value
-				}
-
-				return defaultValue
+				return " = " + parameter.^default.compileExpression.value
 			}
 
-			ParameterTypeString:
+			RaoEnum: {
+				val value = parameter.^default.compileExpression.value
+				val fullTypeName = (parameter.type as RaoEnum).getFullEnumName
+				if (!checkValidEnumID((parameter.type as RaoEnum).getFullEnumName, value))
+					return ""
+
+				return " = " + compileEnumValue(fullTypeName, value)
+			}
+
+			RaoString:
 				return if (parameter.^default != null) ' = "' + parameter.^default + '"' else ""
 
 			default:
@@ -641,7 +619,7 @@ class ResourceTypeCompiler
 		}
 	}
 
-	def private static compileParameterTypes(List<ParameterType> parameters)
+	def private static compileParameterTypes(List<Parameter> parameters)
 	{
 		'''«IF parameters.size > 0»«parameters.get(0).compileType» «
 			parameters.get(0).name»«

--- a/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/generator/GlobalContext.java
+++ b/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/generator/GlobalContext.java
@@ -10,7 +10,7 @@ import ru.bmstu.rk9.rao.rao.EnumerativeSequence;
 import ru.bmstu.rk9.rao.rao.Function;
 import ru.bmstu.rk9.rao.rao.FunctionParameter;
 import ru.bmstu.rk9.rao.rao.HistogramSequence;
-import ru.bmstu.rk9.rao.rao.ParameterType;
+import ru.bmstu.rk9.rao.rao.Parameter;
 import ru.bmstu.rk9.rao.rao.RegularSequence;
 import ru.bmstu.rk9.rao.rao.ResourceCreateStatement;
 import ru.bmstu.rk9.rao.rao.ResourceType;
@@ -27,7 +27,7 @@ public class GlobalContext {
 		public ResourceTypeGlobalReference(ResourceType resourceType) {
 			origin = resourceType;
 			parameters = new HashMap<String, String>();
-			for (ParameterType p : resourceType.getParameters())
+			for (Parameter p : resourceType.getParameters())
 				parameters.put(p.getName(),
 						RaoExpressionCompiler.compileType(p));
 		}

--- a/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/generator/LocalContext.java
+++ b/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/generator/LocalContext.java
@@ -10,7 +10,7 @@ import ru.bmstu.rk9.rao.rao.FunctionAlgorithmic;
 import ru.bmstu.rk9.rao.rao.FunctionList;
 import ru.bmstu.rk9.rao.rao.FunctionParameter;
 import ru.bmstu.rk9.rao.rao.GroupBy;
-import ru.bmstu.rk9.rao.rao.ParameterType;
+import ru.bmstu.rk9.rao.rao.Parameter;
 import ru.bmstu.rk9.rao.rao.Pattern;
 import ru.bmstu.rk9.rao.rao.RaoEnum;
 import ru.bmstu.rk9.rao.rao.RelevantResource;
@@ -112,7 +112,7 @@ public class LocalContext {
 
 	public LocalContext populateWithResourceRename(ResourceType resourceType,
 			String newName) {
-		for (ParameterType parameter : resourceType.getParameters()) {
+		for (Parameter parameter : resourceType.getParameters()) {
 			this.addRawEntry(
 					resourceType.getName() + "." + parameter.getName(),
 					RaoExpressionCompiler.compileType(parameter), newName
@@ -125,7 +125,7 @@ public class LocalContext {
 	}
 
 	public LocalContext populateFromEvent(Event event) {
-		for (ParameterType parameter : event.getParameters())
+		for (Parameter parameter : event.getParameters())
 			this.addRawEntry(parameter.getName(),
 					RaoExpressionCompiler.compileType(parameter), "parameters."
 							+ parameter.getName());
@@ -134,7 +134,7 @@ public class LocalContext {
 	}
 
 	public LocalContext populateFromPattern(Pattern pattern) {
-		for (ParameterType parameter : pattern.getParameters())
+		for (Parameter parameter : pattern.getParameters())
 			this.addRawEntry(parameter.getName(),
 					RaoExpressionCompiler.compileType(parameter), "parameters."
 							+ parameter.getName());
@@ -147,7 +147,7 @@ public class LocalContext {
 				type = ((ResourceCreateStatement) relevantResource.getType())
 						.getType();
 
-			for (ParameterType parameter : type.getParameters())
+			for (Parameter parameter : type.getParameters())
 				this.addRawEntry(
 						relevantResource.getName() + "." + parameter.getName(),
 						RaoExpressionCompiler.compileType(parameter),
@@ -160,7 +160,7 @@ public class LocalContext {
 
 	public void addCreatedResource(
 			ResourceCreateStatement resourceCreateStatement) {
-		for (ParameterType parameter : resourceCreateStatement.getType()
+		for (Parameter parameter : resourceCreateStatement.getType()
 				.getParameters())
 			this.addRawEntry(
 					resourceCreateStatement.getName() + "."

--- a/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/generator/RaoExpressionCompiler.xtend
+++ b/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/generator/RaoExpressionCompiler.xtend
@@ -6,9 +6,6 @@ import static extension ru.bmstu.rk9.rao.generator.RaoNaming.*
 import static extension ru.bmstu.rk9.rao.compilers.EnumCompiler.*
 
 import ru.bmstu.rk9.rao.rao.RaoDefaultParameter
-import ru.bmstu.rk9.rao.rao.ParameterTypeBasic
-import ru.bmstu.rk9.rao.rao.ParameterTypeString
-import ru.bmstu.rk9.rao.rao.ParameterTypeArray
 
 import ru.bmstu.rk9.rao.rao.ResourceCreateStatement
 import ru.bmstu.rk9.rao.rao.ResourceExpressionList
@@ -59,6 +56,9 @@ import ru.bmstu.rk9.rao.rao.TimeNow
 
 import ru.bmstu.rk9.rao.rao.RaoType
 import ru.bmstu.rk9.rao.rao.RaoEnum
+import ru.bmstu.rk9.rao.rao.Parameter
+import org.eclipse.emf.common.util.EList
+import ru.bmstu.rk9.rao.rao.Expression
 
 enum ExpressionOperation
 {
@@ -385,8 +385,15 @@ class RaoExpressionCompiler
 					if (left.value.contains(".get_") && left.value.endsWith("()"))
 					{
 						var operation = (if (idex.operation.length > 1) idex.operation.substring(0, 1) else null)
-						return new RaoExpression(cutLastChars(left.value, 2).replace(".get_", ".set_") + "("
-							+ (if (operation != null) left.value + " " + operation + " " else "") + next.value + ")", left.type)
+						var String value = next.value
+						if (operation != null) {
+							value = left.value + " " + operation + " " + value
+						}
+						if (left.type == "Double")
+							value = "Double.valueOf(" + value + ")"
+
+						return new RaoExpression(cutLastChars(left.value, 2).replace(".get_", ".set_")
+								+ "(" + value + ")", left.type)
 					}
 				}
 
@@ -413,10 +420,10 @@ class RaoExpressionCompiler
 				val parameters = switch parent
 				{
 					ResourceCreateStatement:
-						parent.type.parameters.map[parameter | parameter.compileType]
+						parent.type.parameters
 
 					PlanStatement:
-						parent.event.parameters.map[parameter | parameter.compileType]
+						parent.event.parameters
 				}
 
 				var String list = ""
@@ -428,14 +435,18 @@ class RaoExpressionCompiler
 						list = list + ( if (flag) ", " else "" ) + "null"
 					else
 					{
+						val parameterNumber = expression.expressions.indexOf(resourceParameterExpression)
+						val parameter = if (parameters != null && parameters.size > parameterNumber)
+							parameters.get(parameterNumber) else null
 						val compiled = resourceParameterExpression.compileExpression
 
-						if (parameters != null && compiled.type == "unknown"
-								&& parameters.size > expression.expressions.indexOf(resourceParameterExpression)
-								&& checkValidEnumID(
-									parameters.get(expression.expressions.indexOf(resourceParameterExpression)), compiled.value))
-							compiled.value = parameters.get(expression.expressions.indexOf(resourceParameterExpression)) + "."
+						if (parameter != null && compiled.type == "unknown"
+								&& checkValidEnumID(parameter.compileType, compiled.value))
+							compiled.value = parameter + "."
 									 + compiled.value.substring(compiled.value.lastIndexOf('.') + 1)
+
+						if (parameter != null && parameter.type instanceof RaoDouble)
+							compiled.value = parameter.compileType + ".valueOf(" + compiled.value + ")"
 
 						list = list + ( if (flag) ", " else "" ) + compiled.value
 					}
@@ -447,60 +458,58 @@ class RaoExpressionCompiler
 			DecisionPointActivity:
 			{
 				val pattern = expression.pattern
-				val parameters = pattern.parameters.map[parameter | parameter.compileType]
+				val patternParameters = pattern.parameters
+				val expressionParameters = expression.parameters
 
-				var String list = ""
-				var flag = false
-
-				for (activityParameter : expression.parameters)
-				{
-					val compiled = activityParameter.compileExpression
-					if (parameters != null && compiled.type == "unknown"
-							&& parameters.size > expression.parameters.indexOf(activityParameter)
-							&& checkValidEnumID(
-								parameters.get(expression.parameters.indexOf(activityParameter)), compiled.value
-							)) {
-						compiled.value = compileEnumValue(
-							parameters.get(expression.parameters.indexOf(activityParameter)),
-							compiled.value)
-					}
-
-					list = list + ( if (flag) ", " else "" ) + compiled.value
-					flag = true
-				}
+				var String list = compileActivityParameters(patternParameters, expressionParameters)
 				return new RaoExpression(list, "List")
 			}
 
 			DecisionPointSearchActivity:
 			{
-				val parameters = expression.pattern.parameters.map[p | p.compileType]
+				val pattern = expression.pattern
+				val patternParameters = pattern.parameters
+				val expressionParameters = expression.parameters
 
-				var String list = ""
-				var flag = false
-
-				for (activityParameter : expression.parameters)
-				{
-					val compiled = activityParameter.compileExpression
-
-					if (parameters != null && compiled.type == "unknown"
-							&& parameters.size > expression.parameters.indexOf(activityParameter)
-							&& checkValidEnumID(
-								parameters.get(expression.parameters.indexOf(activityParameter)), compiled.value
-							)) {
-						compiled.value = compileEnumValue(
-							parameters.get(expression.parameters.indexOf(activityParameter)),
-							compiled.value)
-					}
-
-					list = list + ( if (flag) ", " else "" ) + compiled.value
-					flag = true
-				}
+				var String list = compileActivityParameters(patternParameters, expressionParameters)
 				return new RaoExpression(list, "List")
 			}
 
 			default:
 				return new RaoExpression("VAL", "unknown")
 		}
+	}
+
+	def private static compileActivityParameters(
+			EList<Parameter> patternParameters,
+			EList<Expression> arguments
+	)
+	{
+		var String list = ""
+		var flag = false
+
+		for (activityParameter : arguments)
+		{
+			val parameterNumber = arguments.indexOf(activityParameter)
+			val compiled = activityParameter.compileExpression
+			val parameter = if (patternParameters != null && patternParameters.size > parameterNumber)
+					patternParameters.get(parameterNumber) else null
+
+			if (parameter != null && compiled.type == "unknown"
+					&& checkValidEnumID(patternParameters.get(parameterNumber).compileType, compiled.value)) {
+				compiled.value = compileEnumValue(
+					patternParameters.get(parameterNumber).compileType,
+					compiled.value)
+			}
+
+			if (parameter != null && parameter.type instanceof RaoDouble)
+					compiled.value = parameter.compileType + ".valueOf(" + compiled.value + ")"
+
+			list = list + ( if (flag) ", " else "" ) + compiled.value
+			flag = true
+		}
+
+		return list
 	}
 
 	def private static LocalContext.ContextEntry lookupLocal(VariableMethodCallExpression expression)
@@ -582,10 +591,13 @@ class RaoExpressionCompiler
 				var i = 0
 				for (value : next.args.values)
 				{
+					val paramType = params.get(i).type
 					globalCall = globalCall + (if (flag) ", " else "") +
-						if (params.get(i).type.compileType.endsWith("_enum"))
+						if (paramType.compileType.endsWith("_enum"))
 							value.compileExpressionContext((new LocalContext(localContext)).
 								populateWithEnums(params.get(i).type as RaoEnum)).value
+						else if (paramType instanceof RaoDouble)
+							paramType.compileType + ".valueOf(" + value.compileExpression.value + ")"
 						else
 							value.compileExpression.value
 					i = i + 1
@@ -603,10 +615,7 @@ class RaoExpressionCompiler
 	{
 		switch type
 		{
-			ParameterTypeBasic: type.type.compileType
-			ParameterTypeString: type.type.compileType
-			ParameterTypeArray: type.type.compileType
-
+			Parameter: type.type.compileType
 			Constant: type.type.compileType
 
 			RaoInt: "Integer"
@@ -616,7 +625,7 @@ class RaoExpressionCompiler
 			RaoArray: "java.util.ArrayList<" + type.arrayType.compileType + ">"
 			RaoEnum: type.getFullEnumName
 
-			default: "Integer /* TYPE IS ACTUALLY UNKNOWN */"
+			default: "/* ERROR UNKNOWN TYPE */"
 		}
 	}
 
@@ -624,10 +633,7 @@ class RaoExpressionCompiler
 	{
 		switch type
 		{
-			ParameterTypeBasic : type.type.compileTypePrimitive
-			ParameterTypeString: type.type.compileTypePrimitive
-			ParameterTypeArray : type.type.compileTypePrimitive
-
+			Parameter: type.type.compileTypePrimitive
 			Constant: type.type.compileTypePrimitive
 
 			RaoInt: "int"
@@ -637,7 +643,7 @@ class RaoExpressionCompiler
 			RaoArray: "java.util.ArrayList<" + type.arrayType.compileType + ">"
 			RaoEnum: type.getFullEnumName
 
-			default: "int /* TYPE IS ACTUALLY UNKNOWN */"
+			default: "/* ERROR UNKNOWN TYPE */"
 		}
 	}
 
@@ -645,10 +651,7 @@ class RaoExpressionCompiler
 	{
 		switch type
 		{
-			ParameterTypeBasic: type.type
-			ParameterTypeString: type.type
-			ParameterTypeArray: type.type.resolveAllArrays
-
+			Parameter: type.type.resolveAllTypes.resolveAllArrays
 			Constant: type.type.resolveAllTypes.resolveAllArrays
 
 			RaoInt,
@@ -666,9 +669,7 @@ class RaoExpressionCompiler
 	{
 		switch type
 		{
-			ParameterTypeBasic: type.type
-			ParameterTypeString: type.type
-			ParameterTypeArray: type.type
+			Parameter: type.type.resolveAllTypes
 			Constant: type.type.resolveAllTypes
 
 			RaoInt,

--- a/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/generator/RaoNaming.xtend
+++ b/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/generator/RaoNaming.xtend
@@ -9,11 +9,7 @@ import org.eclipse.emf.ecore.EObject
 import ru.bmstu.rk9.rao.rao.RaoModel
 
 import ru.bmstu.rk9.rao.rao.ResourceType
-import ru.bmstu.rk9.rao.rao.ParameterType
-import ru.bmstu.rk9.rao.rao.ParameterTypeBasic
-import ru.bmstu.rk9.rao.rao.ParameterTypeString
-import ru.bmstu.rk9.rao.rao.ParameterTypeArray
-
+import ru.bmstu.rk9.rao.rao.Parameter
 import ru.bmstu.rk9.rao.rao.ResourceCreateStatement
 
 
@@ -78,7 +74,7 @@ class RaoNaming
 			ResourceType:
 				return object.name
 
-			ParameterType:
+			Parameter:
 				return object.name
 
 			ResourceCreateStatement:
@@ -129,7 +125,7 @@ class RaoNaming
 			ResourceType:
 				return object.eContainer.nameGeneric + "." + object.name
 
-			ParameterType:
+			Parameter:
 				return object.eContainer.eContainer.nameGeneric +
 					"." + object.eContainer.nameGeneric + "." + object.name
 
@@ -197,10 +193,6 @@ class RaoNaming
 	{
 		switch type
 		{
-			ParameterTypeBasic : getTypeGenericLabel(type.type)
-			ParameterTypeString: getTypeGenericLabel(type.type)
-			ParameterTypeArray : getTypeGenericLabel(type.type)
-
 			RaoInt: " : " + type.type
 			RaoDouble   : " : " + type.type
 			RaoBoolean: " : " + type.type

--- a/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/generator/RaoStatementCompiler.xtend
+++ b/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/generator/RaoStatementCompiler.xtend
@@ -104,23 +104,26 @@ class RaoStatementCompiler
 			}
 
 			LocalVariableDeclaration:
-				'''
-				«statement.type.compileType» «statement.list.compileStatement»;
-				'''
-
-			VariableDeclarationList:
 			{
+				var variableType = statement.type
 				var flag = false
 				var list = ""
 
-				for (declaration : statement.declarations)
+				for (declaration : statement.list.declarations)
 				{
-					list = list + (if (flag) ", " else "") + declaration.name +
-						(if (declaration.value != null) " = " + declaration.value.compileExpression.value else "")
+					var value = ""
+					if (declaration.value != null) {
+						value = declaration.value.compileExpression.value
+						if (variableType.isStandardType)
+							value = variableType.compileType + ".valueOf(" + value + ")"
+						value = " = " + value
+					}
+
+					list = list + (if (flag) ", " else "") + declaration.name + value
 					flag = true
 				}
 
-				return list
+				return variableType.compileType + " " + list + ";"
 			}
 
 			IfStatement:

--- a/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/validation/RaoValidator.xtend
+++ b/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/validation/RaoValidator.xtend
@@ -42,7 +42,7 @@ import ru.bmstu.rk9.rao.rao.Function
 import ru.bmstu.rk9.rao.rao.FunctionTable
 
 import ru.bmstu.rk9.rao.rao.Pattern
-import ru.bmstu.rk9.rao.rao.ParameterType
+import ru.bmstu.rk9.rao.rao.Parameter
 import ru.bmstu.rk9.rao.rao.PatternSelectMethod
 import ru.bmstu.rk9.rao.rao.RelevantResource
 import ru.bmstu.rk9.rao.rao.Event
@@ -308,7 +308,7 @@ class RaoValidator extends AbstractRaoValidator
 	def checkNamesInPatterns (Pattern pattern)
 	{
 		val List<EObject> parameters  = pattern.eAllContents.filter[eObject |
-			eObject instanceof ParameterType
+			eObject instanceof Parameter
 		].toList
 		val List<EObject> relevantResources = pattern.eAllContents.filter[eObject |
 			eObject instanceof RelevantResource].toList
@@ -355,8 +355,8 @@ class RaoValidator extends AbstractRaoValidator
 			Result:
 				RaoPackage.eINSTANCE.result_Name
 
-			ParameterType:
-				RaoPackage.eINSTANCE.parameterType_Name
+			Parameter:
+				RaoPackage.eINSTANCE.parameter_Name
 
 			RelevantResource:
 				RaoPackage.eINSTANCE.META_ResourceReference_Name


### PR DESCRIPTION
Такой вот код:

``` erlang
type Test {
    double d;
}

resource selftest_resource = Test.create(1);
```

просто не мог скомпилироваться.

Теперь это везде работает. Полную тестовую модель залью в соответствующую репу.
