### PR TITLE
Исправлен вывод трассировки для первого параметра

### DIFF
--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/trace/StringJoiner.java
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/trace/StringJoiner.java
@@ -43,7 +43,7 @@ public class StringJoiner {
 	}
 
 	public final StringJoiner add(final String toAppend) {
-		if (current == null)
+		if (current == "")
 			current = new String(toAppend);
 		else
 			current += delimiter + toAppend;


### PR DESCRIPTION
Появлялись лишние `,` перед первым параметров из-за неправильной проверки.
