### PR TITLE
Удаление неиспользуемого импорта

### DIFF
--- a/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/generator/RaoStatementCompiler.xtend
+++ b/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/generator/RaoStatementCompiler.xtend
@@ -11,7 +11,6 @@ import ru.bmstu.rk9.rao.rao.StatementList
 import ru.bmstu.rk9.rao.rao.ExpressionStatement
 import ru.bmstu.rk9.rao.rao.NestedStatement
 import ru.bmstu.rk9.rao.rao.LocalVariableDeclaration
-import ru.bmstu.rk9.rao.rao.VariableDeclarationList
 import ru.bmstu.rk9.rao.rao.IfStatement
 import ru.bmstu.rk9.rao.rao.ForStatement
 import ru.bmstu.rk9.rao.rao.BreakStatement


### PR DESCRIPTION
Уже после того, как замержил пул-реквест https://github.com/aurusov/rdo-xtext/pull/125, обнаружил, что остался неиспользуемый импорт, вызывающий ворнинг.
