### PR TITLE
Исправление отображения графа

### DIFF
--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphControl.java
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphControl.java
@@ -22,7 +22,8 @@ public class GraphControl {
 	}
 
 	private static void createFrameWindow(FrameInfo frameInfo) {
-		Rectangle monitorBounds = PlatformUI.getWorkbench().getDisplay().getBounds();
+		Rectangle monitorBounds = PlatformUI.getWorkbench().getDisplay()
+				.getBounds();
 		monitorAspectRatio = (double) monitorBounds.width
 				/ monitorBounds.height;
 

--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphView.java
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphView.java
@@ -92,6 +92,9 @@ public class GraphView extends JFrame {
 			/ sizeToLevelDistanceRatio;
 	private final static int fontSize = mxConstants.DEFAULT_FONTSIZE;
 
+	private final Font font;
+	private final double scale = 1.0;
+
 	private final static String solutionColor = "fillColor=32CD32;";
 	private final static String strokeColor = "strokeColor=000000;";
 	private final static String fontColor = "fontColor=000000;";
@@ -173,6 +176,8 @@ public class GraphView extends JFrame {
 
 		if (!isFinished)
 			initializeSubscribers();
+		else if (!nodeList.isEmpty())
+			zoomToFit(graph, layout, graphComponent);
 	}
 
 	private final KeyListener keyListener = new KeyListener() {
@@ -233,11 +238,11 @@ public class GraphView extends JFrame {
 	private final SimulatorSubscriberManager simulationSubscriberManager = new SimulatorSubscriberManager();
 	private final RealTimeSubscriberManager realTimeSubscriberManager = new RealTimeSubscriberManager();
 
-	final mxGraph graph;
-	List<Node> nodeList;
+	private final mxGraph graph;
+	private List<Node> nodeList;
 	final int dptNum;
-	final mxCompactTreeLayout layout;
-	final mxGraphComponent graphComponent;
+	private final mxCompactTreeLayout layout;
+	private final mxGraphComponent graphComponent;
 
 	private final Subscriber commonSubscriber = new Subscriber() {
 		@Override
@@ -348,9 +353,6 @@ public class GraphView extends JFrame {
 			}
 		}
 	}
-
-	final Font font;
-	double scale = 1.0;
 
 	public mxCell insertInfo(mxGraph graph, GraphInfo info) {
 		final String solutionCost = "Стоимость решения: "

--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphView.java
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphView.java
@@ -97,9 +97,6 @@ public class GraphView extends JFrame {
 
 	private final static int fontSize = mxConstants.DEFAULT_FONTSIZE;
 
-	private final Font font;
-	private final double scale = 1.0;
-
 	private final static String solutionFillColor = mxConstants.STYLE_FILLCOLOR
 			+ "=32CD32;";
 	private final static String strokeColor = mxConstants.STYLE_STROKECOLOR
@@ -111,6 +108,15 @@ public class GraphView extends JFrame {
 	private final static String solutionCellStyle = solutionFillColor
 			+ strokeColor + fontColor;
 	private final static String edgeStyle = strokeColor;
+
+	private boolean isFinished = false;
+
+	private int nodeSize;
+	private int nodeDistance;
+	private int levelDistance;
+
+	private final Font font;
+	private final double scale = 1.0;
 
 	public GraphView(int dptNum, int width, int height) {
 		this.setSize(width, height);
@@ -283,11 +289,9 @@ public class GraphView extends JFrame {
 			isFinished = treeBuilder.updateTree();
 			try {
 				drawNewVertex(graph, nodeList);
-				Dimension frameDimension = getSize();
-				Object[] cells = vertexMap.values().toArray();
-				mxRectangle graphBounds = graph.getBoundsForCells(cells, false,
-						false, false);
-				if (graphBounds.getWidth() > frameDimension.getWidth()) {
+				mxRectangle graphBounds = graph.getBoundsForCells(vertexMap
+						.values().toArray(), false, false, false);
+				if (graphBounds.getWidth() > getWidth()) {
 					layout.setMoveTree(true);
 					zoomToFit();
 				} else {
@@ -428,11 +432,6 @@ public class GraphView extends JFrame {
 	// ------------------------------ ZOOM --------------------------------- //
 	// ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― //
 
-	private boolean isFinished = false;
-	private int nodeSize;
-	private int nodeDistance;
-	private int levelDistance;
-
 	private final static double zoomScale = 1.2;
 
 	private void setProportions() {
@@ -477,16 +476,20 @@ public class GraphView extends JFrame {
 				prefferredLevelDistance);
 
 		resizeGraph();
-		setScrollsToCenter();
+		setViewOnRoot();
 	}
 
-	private void setScrollsToCenter() {
+	private void setViewOnRoot() {
 		Rectangle paneBounds = graphComponent.getViewport().getViewRect();
-		Dimension paneSize = graphComponent.getViewport().getViewSize();
+		mxRectangle graphBounds = graph.getBoundsForCells(vertexMap.values()
+				.toArray(), false, false, false);
 
-		int x = (paneSize.width - paneBounds.width) / 2;
-		int y = (paneSize.height - paneBounds.height) / 2;
-		graphComponent.getViewport().setViewPosition(new Point(x, y));
+		int x = (int) ((graphBounds.getWidth() - paneBounds.width) / 2);
+
+		if (x < 0)
+			return;
+
+		graphComponent.getViewport().setViewPosition(new Point(x, 0));
 	}
 
 	private Dimension small = new Dimension();

--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphView.java
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphView.java
@@ -319,7 +319,7 @@ public class GraphView extends JFrame {
 	private void drawGraph(Node parentNode) {
 		mxCell vertex = (mxCell) graph.insertVertex(graph.getDefaultParent(),
 				null, parentNode, getAbsoluteX(0.5), getAbsoluteY(0.05),
-				nodeWidth, nodeHeight, fontColor + strokeColor);
+				nodeSize, nodeSize, fontColor + strokeColor);
 		vertexMap.put(parentNode, vertex);
 		lastAddedVertexIndex = parentNode.index;
 		updateTypicalDimensions(parentNode);
@@ -339,8 +339,8 @@ public class GraphView extends JFrame {
 			if (!vertexMap.containsKey(node)) {
 				mxCell vertex = (mxCell) graph.insertVertex(
 						graph.getDefaultParent(), null, node,
-						getAbsoluteX(0.5), getAbsoluteY(0.05), nodeWidth,
-						nodeHeight, fontColor + strokeColor);
+						getAbsoluteX(0.5), getAbsoluteY(0.05), nodeSize,
+						nodeSize, fontColor + strokeColor);
 				vertexMap.put(node, vertex);
 				lastAddedVertexIndex = node.index;
 				updateTypicalDimensions(node);
@@ -423,8 +423,7 @@ public class GraphView extends JFrame {
 	// ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― //
 
 	private boolean isFinished = false;
-	private int nodeWidth;
-	private int nodeHeight;
+	private int nodeSize;
 	private int nodeDistance;
 	private int levelDistance;
 
@@ -444,8 +443,7 @@ public class GraphView extends JFrame {
 			int levelDistance) {
 		this.levelDistance = levelDistance > minLevelDistance ? levelDistance
 				: minLevelDistance;
-		this.nodeWidth = size > minNodeSize ? size : minNodeSize;
-		this.nodeHeight = this.nodeWidth;
+		this.nodeSize = size > minNodeSize ? size : minNodeSize;
 		this.nodeDistance = nodeDistance > minNodeDistance ? nodeDistance
 				: minNodeDistance;
 	}
@@ -521,9 +519,9 @@ public class GraphView extends JFrame {
 	}
 
 	private final SizeType checkSize() {
-		if (nodeWidth > medium.width && nodeWidth < large.width)
+		if (nodeSize > medium.width && nodeSize < large.width)
 			return SizeType.NORMAL;
-		if (nodeWidth > large.width)
+		if (nodeSize > large.width)
 			return SizeType.FULL;
 
 		return SizeType.BRIEF;
@@ -572,7 +570,7 @@ public class GraphView extends JFrame {
 	}
 
 	private void resizeGraph() {
-		final mxRectangle bound = new mxRectangle(0, 0, nodeWidth, nodeWidth);
+		final mxRectangle bound = new mxRectangle(0, 0, nodeSize, nodeSize);
 		final mxRectangle[] bounds = new mxRectangle[vertexMap.size()];
 		for (int i = 0; i < vertexMap.size(); i++) {
 			bounds[i] = bound;
@@ -592,13 +590,13 @@ public class GraphView extends JFrame {
 	}
 
 	private void zoomIn() {
-		setNodesSize(nodeWidth * zoomScale, nodeDistance * zoomScale,
+		setNodesSize(nodeSize * zoomScale, nodeDistance * zoomScale,
 				levelDistance * zoomScale);
 		resizeGraph();
 	}
 
 	private void zoomOut() {
-		setNodesSize(nodeWidth / zoomScale, nodeDistance / zoomScale,
+		setNodesSize(nodeSize / zoomScale, nodeDistance / zoomScale,
 				levelDistance / zoomScale);
 		resizeGraph();
 	}

--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphView.java
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphView.java
@@ -154,40 +154,43 @@ public class GraphView extends JFrame {
 					}
 				});
 
-		this.addKeyListener(new KeyListener() {
-			@Override
-			public void keyTyped(KeyEvent e) {
-			}
-
-			@Override
-			public void keyReleased(KeyEvent e) {
-			}
-
-			@Override
-			public void keyPressed(KeyEvent e) {
-				if (e.isControlDown() && e.getKeyChar() == '+') {
-					zoomIn(graph, layout);
-				}
-				if (e.isControlDown() && e.getKeyChar() == '-') {
-					zoomOut(graph, layout);
-				}
-				if (e.isControlDown() && e.getKeyChar() != 'z'
-						&& e.getKeyCode() == 90) {
-					Dimension frameDimension = getSize();
-					Object[] cells = vertexMap.values().toArray();
-					mxRectangle graphBounds = graph.getBoundsForCells(cells,
-							false, false, false);
-					while ((graphBounds.getWidth() >= frameDimension.getWidth())
-							&& (nodeWidth > minNodeWidth)) {
-						zoomToFit(graph, layout, graphComponent);
-					}
-				}
-			}
-		});
+		this.addKeyListener(keyListener);
+		graphComponent.addKeyListener(keyListener);
 
 		if (!isFinished)
 			initializeSubscribers();
 	}
+
+	private final KeyListener keyListener = new KeyListener() {
+		@Override
+		public void keyTyped(KeyEvent e) {
+		}
+
+		@Override
+		public void keyReleased(KeyEvent e) {
+		}
+
+		@Override
+		public void keyPressed(KeyEvent e) {
+			char keyChar = e.getKeyChar();
+			if (e.isControlDown() && (keyChar == '+' || keyChar == '=')) {
+				zoomIn(graph, layout);
+			}
+			if (e.isControlDown() && (keyChar == '-' || keyChar == '_')) {
+				zoomOut(graph, layout);
+			}
+			if (e.isControlDown() && (keyChar == '0' || keyChar == ')')) {
+				Dimension frameDimension = getSize();
+				Object[] cells = vertexMap.values().toArray();
+				mxRectangle graphBounds = graph.getBoundsForCells(cells, false,
+						false, false);
+				while ((graphBounds.getWidth() >= frameDimension.getWidth())
+						&& (nodeWidth > minNodeWidth)) {
+					zoomToFit(graph, layout, graphComponent);
+				}
+			}
+		}
+	};
 
 	@Override
 	public void dispose() {

--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphView.java
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphView.java
@@ -362,6 +362,9 @@ public class GraphView extends JFrame {
 	}
 
 	public mxCell showCellInfo(mxGraph graph, mxCell cell) {
+		if (!(cell.getValue() instanceof Node))
+			return null;
+
 		Node cellNode = (Node) cell.getValue();
 		final String nodeIndex = "Номер вершины: "
 				+ Integer.toString(cellNode.index) + "\n";

--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphView.java
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphView.java
@@ -265,7 +265,6 @@ public class GraphView extends JFrame {
 				if (graphBounds.getWidth() > frameDimension.getWidth()) {
 					layout.setMoveTree(true);
 					zoomToFit();
-					graph.refresh();
 				} else {
 					layout.execute(graph.getDefaultParent());
 				}
@@ -461,7 +460,6 @@ public class GraphView extends JFrame {
 
 		resizeGraph();
 		setScrollsToCenter();
-		graph.refresh();
 	}
 
 	private void setScrollsToCenter() {
@@ -577,7 +575,6 @@ public class GraphView extends JFrame {
 		} finally {
 			graph.getModel().endUpdate();
 		}
-		graph.refresh();
 	}
 
 	private void zoomIn() {

--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphView.java
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphView.java
@@ -100,9 +100,17 @@ public class GraphView extends JFrame {
 	private final Font font;
 	private final double scale = 1.0;
 
-	private final static String solutionColor = "fillColor=32CD32;";
-	private final static String strokeColor = "strokeColor=000000;";
-	private final static String fontColor = "fontColor=000000;";
+	private final static String solutionFillColor = mxConstants.STYLE_FILLCOLOR
+			+ "=32CD32;";
+	private final static String strokeColor = mxConstants.STYLE_STROKECOLOR
+			+ "=000000;";
+	private final static String fontColor = mxConstants.STYLE_FONTCOLOR
+			+ "=000000;";
+
+	private final static String regularCellStyle = strokeColor + fontColor;
+	private final static String solutionCellStyle = solutionFillColor
+			+ strokeColor + fontColor;
+	private final static String edgeStyle = strokeColor;
 
 	public GraphView(int dptNum, int width, int height) {
 		this.setSize(width, height);
@@ -319,14 +327,14 @@ public class GraphView extends JFrame {
 	private void drawGraph(Node parentNode) {
 		mxCell vertex = (mxCell) graph.insertVertex(graph.getDefaultParent(),
 				null, parentNode, getAbsoluteX(0.5), getAbsoluteY(0.05),
-				nodeSize, nodeSize, fontColor + strokeColor);
+				nodeSize, nodeSize, regularCellStyle);
 		vertexMap.put(parentNode, vertex);
 		lastAddedVertexIndex = parentNode.index;
 		updateTypicalDimensions(parentNode);
 		if (parentNode.parent != null)
 			graph.insertEdge(graph.getDefaultParent(), null, null,
 					vertexMap.get(parentNode.parent),
-					vertexMap.get(parentNode), strokeColor);
+					vertexMap.get(parentNode), regularCellStyle);
 		if (parentNode.children.size() != 0)
 			for (int i = 0; i < parentNode.children.size(); i++)
 				drawGraph(nodeList.get(parentNode.children.get(i).index));
@@ -340,14 +348,14 @@ public class GraphView extends JFrame {
 				mxCell vertex = (mxCell) graph.insertVertex(
 						graph.getDefaultParent(), null, node,
 						getAbsoluteX(0.5), getAbsoluteY(0.05), nodeSize,
-						nodeSize, fontColor + strokeColor);
+						nodeSize, regularCellStyle);
 				vertexMap.put(node, vertex);
 				lastAddedVertexIndex = node.index;
 				updateTypicalDimensions(node);
 				if (node.parent != null)
 					graph.insertEdge(graph.getDefaultParent(), null, null,
 							vertexMap.get(node.parent), vertexMap.get(node),
-							strokeColor);
+							edgeStyle);
 			}
 		}
 	}
@@ -355,11 +363,9 @@ public class GraphView extends JFrame {
 	public void colorNodes(List<Node> solution) {
 		if (!solution.isEmpty()) {
 			Node rootNode = nodeList.get(0);
-			vertexMap.get(rootNode).setStyle(
-					solutionColor + fontColor + strokeColor);
+			vertexMap.get(rootNode).setStyle(solutionCellStyle);
 			for (int i = 0; i < solution.size(); i++) {
-				vertexMap.get(solution.get(i)).setStyle(
-						solutionColor + fontColor + strokeColor);
+				vertexMap.get(solution.get(i)).setStyle(solutionCellStyle);
 			}
 		}
 	}
@@ -381,7 +387,7 @@ public class GraphView extends JFrame {
 		double height = bounds.getHeight() + delta;
 
 		return (mxCell) graph.insertVertex(graph.getDefaultParent(), null,
-				text, delta, delta, width, height);
+				text, delta, delta, width, height, regularCellStyle);
 	}
 
 	public mxCell showCellInfo(mxGraph graph, mxCell cell) {
@@ -415,7 +421,7 @@ public class GraphView extends JFrame {
 
 		return (mxCell) graph.insertVertex(graph.getDefaultParent(), null,
 				text, getRelativeWidth(1) - width - (delta), delta, width,
-				height);
+				height, regularCellStyle);
 	}
 
 	// ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― //

--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/TreeBuilder.java
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/TreeBuilder.java
@@ -44,6 +44,7 @@ public class TreeBuilder {
 		public String ruleDesсription;
 		public double ruleCost;
 		public String label;
+		public int depthLevel;
 
 		@Override
 		public String toString() {
@@ -77,6 +78,8 @@ public class TreeBuilder {
 			treeNode.parent = null;
 			treeNode.index = 0;
 			treeNode.label = Integer.toString(treeNode.index);
+			treeNode.depthLevel = 1;
+			graphInfo.depth = 1;
 			nodeList.add(treeNode);
 			lastAddedNodeIndex = treeNode.index;
 			break;
@@ -84,7 +87,6 @@ public class TreeBuilder {
 		case END: {
 			final ByteBuffer data = Tracer.prepareBufferForReading(entry
 					.getData());
-			graphInfo = new GraphInfo();
 			Tracer.skipPart(data, TypeSize.BYTE + TypeSize.LONG * 2);
 
 			final double finalCost = data.getDouble();
@@ -104,7 +106,6 @@ public class TreeBuilder {
 					.getData());
 			final DecisionPointSearch.SpawnStatus spawnStatus = DecisionPointSearch.SpawnStatus
 					.values()[data.get()];
-			// TODO delete spawn
 			switch (spawnStatus) {
 			case NEW:
 			case BETTER:
@@ -152,6 +153,9 @@ public class TreeBuilder {
 				treeNode.ruleCost = ruleCost;
 				treeNode.index = nodeNumber;
 				treeNode.label = Integer.toString(treeNode.index);
+				treeNode.depthLevel = treeNode.parent.depthLevel + 1;
+				if (treeNode.depthLevel > graphInfo.depth)
+					graphInfo.depth = treeNode.depthLevel;
 				nodeList.add(treeNode);
 				lastAddedNodeIndex = treeNode.index;
 				break;
@@ -185,6 +189,7 @@ public class TreeBuilder {
 		public double solutionCost;
 		public int numOpened;
 		public int numNodes;
+		public int depth;
 	}
 
 	public int getEntryNumber() {


### PR DESCRIPTION
- починен зум по нажатию `+/-/0`
- исправлено оптимальное размещение графа в окне (`zoom to fit`)
- исправлено несколько мелких ошибок

Результат вызова `zoomToFit()` теперь выглядит так:
![graph](https://cloud.githubusercontent.com/assets/6528492/9776976/1249c732-5767-11e5-9f42-45b67fe04d88.png)
