### PR TITLE
Запрет сборки для моделей с ошибками валидации

### DIFF
--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/build/BuildHandler.java
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/build/BuildHandler.java
@@ -6,6 +6,7 @@ import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.xtext.builder.EclipseOutputConfigurationProvider;
 import org.eclipse.xtext.builder.EclipseResourceFileSystemAccess2;
 import org.eclipse.xtext.ui.resource.IResourceSetProvider;
+import org.eclipse.xtext.ui.validation.DefaultResourceUIValidatorExtension;
 
 import ru.bmstu.rk9.rao.IMultipleResourceGenerator;
 
@@ -25,11 +26,14 @@ public class BuildHandler extends AbstractHandler {
 	@Inject
 	EclipseOutputConfigurationProvider outputConfigurationProvider;
 
+	@Inject
+	DefaultResourceUIValidatorExtension validatorExtension;
+
 	@Override
 	public Object execute(ExecutionEvent event) throws ExecutionException {
 		ModelBuilder.build(event, fileAccessProvider.get(),
-				resourceSetProvider, outputConfigurationProvider, generator)
-				.schedule();
+				resourceSetProvider, outputConfigurationProvider, generator,
+				validatorExtension).schedule();
 		return null;
 	}
 }

--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/build/ModelBuilder.java
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/build/ModelBuilder.java
@@ -229,6 +229,11 @@ public class ModelBuilder {
 				for (IResource resource : raoFiles) {
 					Resource loadedResource = resourceSet.getResource(
 							BuildUtil.getURI(resource), true);
+					if (!loadedResource.getErrors().isEmpty()) {
+						projectHasErrors = true;
+						break;
+					}
+
 					try {
 						validatorExtension.updateValidationMarkers(
 								(IFile) resource, loadedResource,
@@ -246,10 +251,6 @@ public class ModelBuilder {
 								pluginId,
 								"Build failed: internal error whule calculating model error markers",
 								e);
-					}
-					if (!loadedResource.getErrors().isEmpty()) {
-						projectHasErrors = true;
-						break;
 					}
 				}
 

--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/build/ModelBuilder.java
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/build/ModelBuilder.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
@@ -44,6 +45,8 @@ import org.eclipse.xtext.builder.EclipseResourceFileSystemAccess2;
 import org.eclipse.xtext.generator.OutputConfiguration;
 import org.eclipse.xtext.ui.editor.XtextEditor;
 import org.eclipse.xtext.ui.resource.IResourceSetProvider;
+import org.eclipse.xtext.ui.validation.DefaultResourceUIValidatorExtension;
+import org.eclipse.xtext.validation.CheckMode;
 import org.osgi.framework.Bundle;
 
 import ru.bmstu.rk9.rao.IMultipleResourceGenerator;
@@ -144,7 +147,8 @@ public class ModelBuilder {
 			final EclipseResourceFileSystemAccess2 fsa,
 			final IResourceSetProvider resourceSetProvider,
 			final EclipseOutputConfigurationProvider ocp,
-			final IMultipleResourceGenerator generator) {
+			final IMultipleResourceGenerator generator,
+			final DefaultResourceUIValidatorExtension validatorExtension) {
 		final String pluginId = "ru.bmstu.rk9.rao.ui";
 		Job buildJob = new Job("Building Rao model") {
 			protected IStatus run(IProgressMonitor monitor) {
@@ -217,19 +221,6 @@ public class ModelBuilder {
 					return new Status(Status.ERROR, pluginId,
 							srcGenErrorMessage);
 
-				fsa.setOutputPath(srcGenFolder.getFullPath().toString());
-
-				fsa.setMonitor(monitor);
-				fsa.setProject(project);
-
-				Map<String, OutputConfiguration> outputConfigurations = new HashMap<String, OutputConfiguration>();
-
-				for (OutputConfiguration oc : ocp
-						.getOutputConfigurations(project))
-					outputConfigurations.put(oc.getName(), oc);
-
-				fsa.setOutputConfigurations(outputConfigurations);
-
 				final ResourceSet resourceSet = resourceSetProvider
 						.get(project);
 
@@ -238,6 +229,24 @@ public class ModelBuilder {
 				for (IResource resource : raoFiles) {
 					Resource loadedResource = resourceSet.getResource(
 							BuildUtil.getURI(resource), true);
+					try {
+						validatorExtension.updateValidationMarkers(
+								(IFile) resource, loadedResource,
+								CheckMode.ALL, monitor);
+						IMarker[] markers = resource.findMarkers(
+								IMarker.PROBLEM, true, 0);
+						if (markers.length > 0) {
+							projectHasErrors = true;
+							break;
+						}
+					} catch (CoreException e) {
+						e.printStackTrace();
+						return new Status(
+								Status.ERROR,
+								pluginId,
+								"Build failed: internal error whule calculating model error markers",
+								e);
+					}
 					if (!loadedResource.getErrors().isEmpty()) {
 						projectHasErrors = true;
 						break;
@@ -253,6 +262,19 @@ public class ModelBuilder {
 					return new Status(Status.ERROR, pluginId,
 							"Build failed: model has errors");
 				}
+
+				fsa.setOutputPath(srcGenFolder.getFullPath().toString());
+
+				fsa.setMonitor(monitor);
+				fsa.setProject(project);
+
+				Map<String, OutputConfiguration> outputConfigurations = new HashMap<String, OutputConfiguration>();
+
+				for (OutputConfiguration oc : ocp
+						.getOutputConfigurations(project))
+					outputConfigurations.put(oc.getName(), oc);
+
+				fsa.setOutputConfigurations(outputConfigurations);
 
 				generator.doGenerate(resourceSet, fsa);
 
@@ -285,7 +307,7 @@ public class ModelBuilder {
 					return new Status(
 							Status.ERROR,
 							pluginId,
-							"Build failed: internal error whule calculating error markers",
+							"Build failed: internal error whule calculating generated files error markers",
 							e);
 				}
 

--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/run/ExecutionHandler.java
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/run/ExecutionHandler.java
@@ -27,6 +27,7 @@ import org.eclipse.ui.services.ISourceProviderService;
 import org.eclipse.xtext.builder.EclipseOutputConfigurationProvider;
 import org.eclipse.xtext.builder.EclipseResourceFileSystemAccess2;
 import org.eclipse.xtext.ui.resource.IResourceSetProvider;
+import org.eclipse.xtext.ui.validation.DefaultResourceUIValidatorExtension;
 
 import ru.bmstu.rk9.rao.IMultipleResourceGenerator;
 import ru.bmstu.rk9.rao.lib.animation.AnimationFrame;
@@ -58,6 +59,9 @@ public class ExecutionHandler extends AbstractHandler {
 	@Inject
 	private EclipseOutputConfigurationProvider outputConfigurationProvider;
 
+	@Inject
+	DefaultResourceUIValidatorExtension validatorExtension;
+
 	private static boolean isRunning = false;
 
 	public static boolean getRunningState() {
@@ -86,7 +90,8 @@ public class ExecutionHandler extends AbstractHandler {
 		setRunningState(display, sourceProvider, true);
 
 		final Job build = ModelBuilder.build(event, fileAccessProvider.get(),
-				resourceSetProvider, outputConfigurationProvider, generator);
+				resourceSetProvider, outputConfigurationProvider, generator,
+				validatorExtension);
 		build.schedule();
 
 		IEditorPart activeEditor = HandlerUtil.getActiveEditor(event);


### PR DESCRIPTION
Перед началом генерации `Java`-кода модели производится проверка на наличие в модели ошибок. Грамматические ошибки могут быть найдены методом `getErrors()` у файла модели. Однако ошибки валидации таким образом не обнаруживаются (по неизвестным мне причинам). Поэтому для их обнаружения необходимо проверить наличие маркеров ошибок для файла (те самые красные кружочки слева от кода). Это и делается в данном пул-реквесте.
