### PR TITLE
 Исправление ошибок при поиске по графу

### DIFF
--- a/ru.bmstu.rk9.rao.lib/src/ru/bmstu/rk9/rao/lib/dpt/DecisionPointSearch.java
+++ b/ru.bmstu.rk9.rao.lib/src/ru/bmstu/rk9/rao/lib/dpt/DecisionPointSearch.java
@@ -136,7 +136,8 @@ public class DecisionPointSearch<T extends ModelState<T>> extends DecisionPoint 
 				return -1;
 			if (x.g + x.h > y.g + y.h)
 				return 1;
-			return 0;
+
+			return x.number - y.number;
 		}
 	};
 

--- a/ru.bmstu.rk9.rao.lib/src/ru/bmstu/rk9/rao/lib/dpt/DecisionPointSearch.java
+++ b/ru.bmstu.rk9.rao.lib/src/ru/bmstu/rk9/rao/lib/dpt/DecisionPointSearch.java
@@ -208,10 +208,17 @@ public class DecisionPointSearch<T extends ModelState<T>> extends DecisionPoint 
 						data);
 			}
 
-			if (terminate.check())
-				return stop(StopCode.SUCCESS);
-
 			current.children = spawnChildren(current);
+			for (GraphNode child : current.children) {
+				child.state.deploy();
+				if (terminate.check()) {
+					current = child;
+					return stop(StopCode.SUCCESS);
+				}
+
+				current.state.deploy();
+			}
+
 			nodesOpen.addAll(current.children);
 		}
 		head.state.deploy();

--- a/ru.bmstu.rk9.rao.lib/src/ru/bmstu/rk9/rao/lib/dpt/DecisionPointSearch.java
+++ b/ru.bmstu.rk9.rao.lib/src/ru/bmstu/rk9/rao/lib/dpt/DecisionPointSearch.java
@@ -210,6 +210,8 @@ public class DecisionPointSearch<T extends ModelState<T>> extends DecisionPoint 
 			}
 
 			current.children = spawnChildren(current);
+			nodesOpen.addAll(current.children);
+
 			for (GraphNode child : current.children) {
 				child.state.deploy();
 				if (terminate.check()) {
@@ -219,8 +221,6 @@ public class DecisionPointSearch<T extends ModelState<T>> extends DecisionPoint 
 
 				current.state.deploy();
 			}
-
-			nodesOpen.addAll(current.children);
 		}
 		head.state.deploy();
 		return stop(StopCode.FAIL);

--- a/ru.bmstu.rk9.rao.lib/src/ru/bmstu/rk9/rao/lib/dpt/DecisionPointSearch.java
+++ b/ru.bmstu.rk9.rao.lib/src/ru/bmstu/rk9/rao/lib/dpt/DecisionPointSearch.java
@@ -181,6 +181,8 @@ public class DecisionPointSearch<T extends ModelState<T>> extends DecisionPoint 
 
 		head = new GraphNode(totalAdded++, null);
 		head.state = retriever.get();
+		nodesClosed.add(head);
+
 		head.children = spawnChildren(head);
 
 		nodesOpen.addAll(head.children);


### PR DESCRIPTION
Пересоздал после https://github.com/aurusov/rdo-xtext/pull/250

На данной раскладке:

``` erlang
resource Фишка1 = Фишка.create(1, 2);
resource Фишка2 = Фишка.create(2, 5);
resource Фишка3 = Фишка.create(3, 3);
resource Фишка4 = Фишка.create(4, 1);
resource Фишка5 = Фишка.create(5, 6);
resource Дырка = Дырка_t.create(4);
```

Было так:
![123](https://cloud.githubusercontent.com/assets/6528492/10864159/f348454a-7ff5-11e5-8c28-7d75806ded51.png)
Теперь так:
![dpt_search](https://cloud.githubusercontent.com/assets/6528492/10864825/e45164b2-800a-11e5-9e7d-e81620b5b1c8.png)

Прошу всех посмотреть.
@aurusov 
@LeKaitoW 
@AlexChernov 
