### PR TITLE
Переработка окошка с состоянием графа

### DIFF
--- a/ru.bmstu.rk9.rao.lib/src/ru/bmstu/rk9/rao/lib/dpt/DecisionPointSearch.java
+++ b/ru.bmstu.rk9.rao.lib/src/ru/bmstu/rk9/rao/lib/dpt/DecisionPointSearch.java
@@ -304,7 +304,8 @@ public class DecisionPointSearch<T extends ModelState<T>> extends DecisionPoint 
 				}
 
 				if (enoughSensitivity(SerializationLevel.ALL)) {
-					executed.addResourceEntriesToDatabase(Pattern.ExecutedFrom.SEARCH);
+					executed.addResourceEntriesToDatabase(
+							Pattern.ExecutedFrom.SEARCH, this.getName());
 				}
 
 				Simulator.getExecutionStateNotifier().notifySubscribers(
@@ -393,7 +394,8 @@ public class DecisionPointSearch<T extends ModelState<T>> extends DecisionPoint 
 						Database.SearchEntryType.DECISION, data);
 
 				if (enoughSensitivity(SerializationLevel.ALL)) {
-					rule.addResourceEntriesToDatabase(Pattern.ExecutedFrom.SOLUTION);
+					rule.addResourceEntriesToDatabase(
+							Pattern.ExecutedFrom.SOLUTION, this.getName());
 				}
 			}
 		}

--- a/ru.bmstu.rk9.rao.lib/src/ru/bmstu/rk9/rao/lib/pattern/Pattern.java
+++ b/ru.bmstu.rk9.rao.lib/src/ru/bmstu/rk9/rao/lib/pattern/Pattern.java
@@ -4,8 +4,6 @@ import ru.bmstu.rk9.rao.lib.database.Database;
 
 public interface Pattern {
 	public static enum ExecutedFrom {
-		SOME    (null),
-		PRIOR   (null),
 		SEARCH  (Database.ResourceEntryType.SEARCH),
 		SOLUTION(Database.ResourceEntryType.SOLUTION);
 

--- a/ru.bmstu.rk9.rao.lib/src/ru/bmstu/rk9/rao/lib/pattern/Rule.java
+++ b/ru.bmstu.rk9.rao.lib/src/ru/bmstu/rk9/rao/lib/pattern/Rule.java
@@ -2,5 +2,5 @@ package ru.bmstu.rk9.rao.lib.pattern;
 
 
 public interface Rule extends Pattern {
-	public void addResourceEntriesToDatabase(Pattern.ExecutedFrom executedFrom);
+	public void addResourceEntriesToDatabase(Pattern.ExecutedFrom executedFrom, String dptName);
 }

--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphApi.java
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphApi.java
@@ -1,7 +1,7 @@
 package ru.bmstu.rk9.rao.ui.graph;
 
 import ru.bmstu.rk9.rao.lib.notification.Notifier;
-import ru.bmstu.rk9.rao.ui.graph.GraphView.GraphEvent;
+import ru.bmstu.rk9.rao.ui.graph.GraphPanel.GraphEvent;
 
 import com.mxgraph.view.mxGraph;
 

--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphControl.java
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphControl.java
@@ -1,13 +1,11 @@
 package ru.bmstu.rk9.rao.ui.graph;
 
-import java.awt.Frame;
 import java.awt.event.WindowEvent;
 import java.awt.event.WindowListener;
 import java.util.HashMap;
 import java.util.Map;
-import javax.swing.JFrame;
 
-import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.PlatformUI;
 
 public class GraphControl {
@@ -22,26 +20,19 @@ public class GraphControl {
 	}
 
 	private static void createFrameWindow(FrameInfo frameInfo) {
-		Rectangle monitorBounds = PlatformUI.getWorkbench().getDisplay()
-				.getBounds();
-		monitorAspectRatio = (double) monitorBounds.width
-				/ monitorBounds.height;
+		Display display = PlatformUI.getWorkbench().getDisplay();
 
 		int dptNum = frameInfo.dptNumber;
 		String frameName = frameInfo.frameName;
 
-		int frameWidth = setWidth(monitorBounds, 1.2);
-		int frameHeight = setHeight(monitorBounds, 0.8);
+		GraphShell graphShell = new GraphShell(display, dptNum);
+		graphShell.open();
 
-		GraphView graphFrame = new GraphView(dptNum, frameWidth, frameHeight);
+		GraphControl.openedGraphMap.put(dptNum, graphShell);
+		graphShell.setText(frameName);
+		graphShell.getGraphFrame().setVisible(true);
 
-		GraphControl.openedGraphMap.put(dptNum, graphFrame);
-		graphFrame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-		graphFrame.setTitle(frameName);
-		graphFrame.setLocationRelativeTo(null);
-		graphFrame.setVisible(true);
-
-		graphFrame.addWindowListener(new WindowListener() {
+		graphShell.getGraphFrame().addWindowListener(new WindowListener() {
 			@Override
 			public void windowOpened(WindowEvent e) {
 			}
@@ -77,24 +68,11 @@ public class GraphControl {
 		if (!GraphControl.openedGraphMap.containsKey(frameInfo.dptNumber)) {
 			GraphControl.createFrameWindow(frameInfo);
 		} else {
-			GraphView currentFrame = GraphControl.openedGraphMap
+			GraphShell currentGraphShell = GraphControl.openedGraphMap
 					.get(frameInfo.dptNumber);
-			if (currentFrame.getState() == Frame.ICONIFIED)
-				currentFrame.setState(Frame.NORMAL);
-			else if (!currentFrame.isActive())
-				currentFrame.setVisible(true);
+			currentGraphShell.forceActive();
 		}
 	}
 
-	public static final Map<Integer, GraphView> openedGraphMap = new HashMap<Integer, GraphView>();
-
-	private static double monitorAspectRatio;
-
-	public static int setWidth(Rectangle r, double relativeWidth) {
-		return (int) (r.width * relativeWidth / GraphControl.monitorAspectRatio);
-	}
-
-	public static int setHeight(Rectangle r, double relativeHeight) {
-		return (int) (r.height * relativeHeight);
-	}
+	private static final Map<Integer, GraphShell> openedGraphMap = new HashMap<Integer, GraphShell>();
 }

--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphInfoWindow.java
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphInfoWindow.java
@@ -2,6 +2,7 @@ package ru.bmstu.rk9.rao.ui.graph;
 
 import java.util.List;
 
+import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.layout.TableColumnLayout;
 import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.ColumnLabelProvider;
@@ -14,20 +15,36 @@ import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.FormAttachment;
 import org.eclipse.swt.layout.FormData;
 import org.eclipse.swt.layout.FormLayout;
+import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
 
-public class GraphInfoWindow extends Shell {
-	GraphInfoWindow(Display display) {
-		super(display, SWT.SHELL_TRIM);
-		setText("Graph Info");
-		setLayout(new FillLayout());
+public class GraphInfoWindow extends Dialog {
+	protected GraphInfoWindow(Shell parentShell) {
+		super(parentShell);
+		setShellStyle(SWT.CLOSE | SWT.MODELESS | SWT.BORDER | SWT.TITLE);
+	}
 
-		scrolledWindowArea = new ScrolledComposite(this, SWT.H_SCROLL
-				| SWT.V_SCROLL | SWT.FILL);
+	@Override
+	protected void configureShell(Shell newShell) {
+		super.configureShell(newShell);
+		newShell.setText("Graph Info");
+	}
+
+	@Override
+	protected Control createButtonBar(final Composite parent) {
+		return null;
+	}
+
+	@Override
+	protected Control createDialogArea(Composite parent) {
+		Composite area = (Composite) super.createDialogArea(parent);
+		area.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+
+		scrolledWindowArea = new ScrolledComposite(area, SWT.H_SCROLL | SWT.V_SCROLL | SWT.FILL);
 		scrolledWindowArea.setLayout(new FillLayout());
 		scrolledWindowArea.setExpandHorizontal(true);
 		scrolledWindowArea.setExpandVertical(true);
@@ -64,19 +81,17 @@ public class GraphInfoWindow extends Shell {
 		buttonNext.setLayoutData(buttonNextFormData);
 
 		scrolledWindowArea.setContent(windowArea);
+
+		return area;
 	}
 
-	@Override
-	protected void checkSubclass() {
-	}
+	private ScrolledComposite scrolledWindowArea;
+	private Composite windowArea;
+	private Composite infoArea;
+	private Composite buttonArea;
 
-	private final ScrolledComposite scrolledWindowArea;
-	private final Composite windowArea;
-	private final Composite infoArea;
-	private final Composite buttonArea;
-
-	private final Button buttonNext;
-	private final Button buttonPrevious;
+	private Button buttonNext;
+	private Button buttonPrevious;
 
 	public final Composite getInfoArea() {
 		return infoArea;
@@ -90,8 +105,8 @@ public class GraphInfoWindow extends Shell {
 		return buttonPrevious;
 	}
 
-	private final InfoTableWrapper cellInfoViewerWrapper;
-	private final InfoTableWrapper graphInfoViewerWrapper;
+	private InfoTableWrapper cellInfoViewerWrapper;
+	private InfoTableWrapper graphInfoViewerWrapper;
 
 	static class InfoElement {
 		public InfoElement(String key, String value) {
@@ -121,7 +136,7 @@ public class GraphInfoWindow extends Shell {
 
 	private class InfoTableWrapper {
 		public static final int infoKeyColumnWidth = 200;
-		public static final int infoValueColumnWidth = 300;
+		public static final int infoValueColumnWidth = 200;
 
 		private final Composite composite;
 		private final TableViewer tableViewer;
@@ -130,8 +145,7 @@ public class GraphInfoWindow extends Shell {
 			composite = new Composite(parent, SWT.FILL | SWT.BORDER);
 			tableViewer = new TableViewer(composite, SWT.FILL);
 
-			TableViewerColumn keyColumn = new TableViewerColumn(tableViewer,
-					SWT.NONE);
+			TableViewerColumn keyColumn = new TableViewerColumn(tableViewer, SWT.NONE);
 			keyColumn.setLabelProvider(new ColumnLabelProvider() {
 				@Override
 				public String getText(Object element) {
@@ -140,8 +154,7 @@ public class GraphInfoWindow extends Shell {
 				}
 			});
 
-			TableViewerColumn valueColumn = new TableViewerColumn(tableViewer,
-					SWT.NONE);
+			TableViewerColumn valueColumn = new TableViewerColumn(tableViewer, SWT.NONE);
 			valueColumn.setLabelProvider(new ColumnLabelProvider() {
 				@Override
 				public String getText(Object element) {
@@ -153,10 +166,8 @@ public class GraphInfoWindow extends Shell {
 			tableViewer.setContentProvider(new ArrayContentProvider());
 
 			TableColumnLayout tableLayout = new TableColumnLayout();
-			tableLayout.setColumnData(keyColumn.getColumn(),
-					new ColumnWeightData(0, infoKeyColumnWidth));
-			tableLayout.setColumnData(valueColumn.getColumn(),
-					new ColumnWeightData(0, infoValueColumnWidth));
+			tableLayout.setColumnData(keyColumn.getColumn(), new ColumnWeightData(0, infoKeyColumnWidth));
+			tableLayout.setColumnData(valueColumn.getColumn(), new ColumnWeightData(0, infoValueColumnWidth));
 			composite.setLayout(tableLayout);
 
 			tableViewer.getTable().setLinesVisible(true);
@@ -171,8 +182,7 @@ public class GraphInfoWindow extends Shell {
 		}
 
 		private final void update() {
-			scrolledWindowArea.setMinSize(windowArea.computeSize(SWT.DEFAULT,
-					SWT.DEFAULT));
+			scrolledWindowArea.setMinSize(windowArea.computeSize(SWT.DEFAULT, SWT.DEFAULT));
 		}
 	}
 }

--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphPanel.java
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphPanel.java
@@ -21,6 +21,7 @@ import javax.swing.JPanel;
 
 import org.eclipse.jdt.ui.PreferenceConstants;
 import org.eclipse.jface.resource.FontRegistry;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.widgets.Display;
@@ -465,8 +466,11 @@ public class GraphPanel extends JPanel implements GraphApi {
 		} else {
 			graphInfoWindow = new GraphInfoWindow(display);
 			graphInfoWindow.open();
+
 			graphEventNotifier
 					.notifySubscribers(GraphEvent.GRAPHINFO_WINDOW_OPENED);
+			graphInfoWindow.setSize(graphInfoWindow.computeSize(SWT.DEFAULT,
+					SWT.DEFAULT));
 		}
 	}
 

--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphShell.java
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphShell.java
@@ -1,0 +1,52 @@
+package ru.bmstu.rk9.rao.ui.graph;
+
+import java.awt.BorderLayout;
+import java.awt.Frame;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.awt.SWT_AWT;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+
+public class GraphShell extends Shell {
+	public GraphShell(Display display, int dptNum) {
+		super(display, SWT.SHELL_TRIM);
+		setLayout(new FillLayout());
+
+		Composite graphFrameContainer = new Composite(this, SWT.EMBEDDED
+				| SWT.NO_BACKGROUND | SWT.FILL);
+		graphFrameContainer.setLayout(new FillLayout());
+
+		graphFrame = SWT_AWT.new_Frame(graphFrameContainer);
+		graphFrame.setLayout(new BorderLayout());
+		graphPanel = new GraphPanel(dptNum);
+		graphFrame.add(BorderLayout.CENTER, graphPanel);
+		graphFrame.addKeyListener(graphPanel.getZoomKeyListener());
+		graphFrame.addComponentListener(graphPanel
+				.getZoomToFitComponentListener());
+		graphFrame.pack();
+	}
+
+	private final Frame graphFrame;
+	private final GraphPanel graphPanel;
+
+	public final Frame getGraphFrame() {
+		return graphFrame;
+	}
+
+	public final GraphPanel getGraphPanel() {
+		return graphPanel;
+	}
+
+	@Override
+	public void dispose() {
+		graphPanel.onDispose();
+		super.dispose();
+	}
+
+	@Override
+	protected void checkSubclass() {
+	}
+}

--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphShell.java
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphShell.java
@@ -21,7 +21,7 @@ public class GraphShell extends Shell {
 
 		graphFrame = SWT_AWT.new_Frame(graphFrameContainer);
 		graphFrame.setLayout(new BorderLayout());
-		graphPanel = new GraphPanel(dptNum);
+		graphPanel = new GraphPanel(dptNum, this);
 		graphFrame.add(BorderLayout.CENTER, graphPanel);
 		graphFrame.addKeyListener(graphPanel.getZoomKeyListener());
 		graphFrame.addComponentListener(graphPanel

--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphView.java
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphView.java
@@ -513,7 +513,7 @@ public class GraphView extends JFrame implements GraphApi {
 				.valueOf(node.g)));
 		cellInfoList.add(new InfoElement("Remaining path cost (h)", String
 				.valueOf(node.h)));
-		cellInfoList.add(new InfoElement("Full path cost (h)", String
+		cellInfoList.add(new InfoElement("Full path cost (f)", String
 				.valueOf(node.h + node.g)));
 		cellInfoList.add(new InfoElement("Rule used", node.ruleName));
 		cellInfoList.add(new InfoElement("Relevant resources",
@@ -620,13 +620,13 @@ public class GraphView extends JFrame implements GraphApi {
 				: minNodeDistance;
 	}
 
-	private void zoomToFit() {
+	private final void zoomToFit() {
 		// TODO implement fitInWidth() algorithm and choose
 		// appropriate strategy depending on graph width a
 		fitInDepth();
 	}
 
-	private void fitInDepth() {
+	private final void fitInDepth() {
 		int height = getContentPane().getHeight();
 		int depth = treeBuilder.graphInfo.depth;
 
@@ -641,7 +641,7 @@ public class GraphView extends JFrame implements GraphApi {
 		setViewOnRoot();
 	}
 
-	private void setViewOnRoot() {
+	private final void setViewOnRoot() {
 		Rectangle paneBounds = graphComponent.getViewport().getViewRect();
 		mxRectangle graphBounds = graph.getBoundsForCells(vertexByNode.values()
 				.toArray(), false, false, false);
@@ -654,11 +654,11 @@ public class GraphView extends JFrame implements GraphApi {
 		graphComponent.getViewport().setViewPosition(new Point(x, 0));
 	}
 
-	private Dimension small = new Dimension();
-	private Dimension medium = new Dimension();
-	private Dimension large = new Dimension();
+	private final Dimension small = new Dimension();
+	private final Dimension medium = new Dimension();
+	private final Dimension large = new Dimension();
 
-	private void updateTypicalDimensions(Node node) {
+	private final void updateTypicalDimensions(Node node) {
 		final String number = Integer.toString(node.index);
 		final String costFunction = Double.toString(node.g + node.h) + " = "
 				+ Double.toString(node.g) + " + " + Double.toString(node.h);
@@ -698,7 +698,7 @@ public class GraphView extends JFrame implements GraphApi {
 		return SizeType.BRIEF;
 	}
 
-	private void setTextForVertexes() {
+	private final void setTextForVertexes() {
 		SizeType type = checkSize();
 		switch (type) {
 		case BRIEF:
@@ -740,7 +740,7 @@ public class GraphView extends JFrame implements GraphApi {
 		}
 	}
 
-	private void resizeGraph() {
+	private final void resizeGraph() {
 		final mxRectangle bound = new mxRectangle(0, 0, nodeSize, nodeSize);
 		final mxRectangle[] bounds = new mxRectangle[vertexByNode.size()];
 		for (int i = 0; i < vertexByNode.size(); i++) {
@@ -760,12 +760,12 @@ public class GraphView extends JFrame implements GraphApi {
 		}
 	}
 
-	private void zoomIn() {
+	private final void zoomIn() {
 		setNodesSize(nodeSize * zoomScale);
 		resizeGraph();
 	}
 
-	private void zoomOut() {
+	private final void zoomOut() {
 		setNodesSize(nodeSize / zoomScale);
 		resizeGraph();
 	}
@@ -774,23 +774,23 @@ public class GraphView extends JFrame implements GraphApi {
 	// ----------------------- RELATIVE COORDINATES ------------------------ //
 	// ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― //
 
-	private double getAspectRatio() {
+	private final double getAspectRatio() {
 		return ((double) this.getWidth()) / this.getHeight();
 	}
 
-	public int getAbsoluteX(double ratio) {
+	public final int getAbsoluteX(double ratio) {
 		return (int) (getWidth() * ratio);
 	}
 
-	public int getAbsoluteY(double ratio) {
+	public final int getAbsoluteY(double ratio) {
 		return (int) (getHeight() * ratio);
 	}
 
-	public int getRelativeWidth(double ratio) {
+	public final int getRelativeWidth(double ratio) {
 		return (int) (getWidth() * ratio / getAspectRatio());
 	}
 
-	public int getRelativeHeight(double ratio) {
+	public final int getRelativeHeight(double ratio) {
 		return (int) (getHeight() * ratio);
 	}
 }

--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphView.java
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/GraphView.java
@@ -11,6 +11,7 @@ import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -35,6 +36,7 @@ import ru.bmstu.rk9.rao.lib.simulator.Simulator.ExecutionState;
 import ru.bmstu.rk9.rao.lib.simulator.SimulatorSubscriberManager;
 import ru.bmstu.rk9.rao.lib.simulator.SimulatorSubscriberManager.SimulatorSubscriberInfo;
 import ru.bmstu.rk9.rao.ui.graph.GraphControl.FrameInfo;
+import ru.bmstu.rk9.rao.ui.graph.GraphInfoWindow.InfoElement;
 import ru.bmstu.rk9.rao.ui.graph.TreeBuilder.GraphInfo;
 import ru.bmstu.rk9.rao.ui.graph.TreeBuilder.Node;
 import ru.bmstu.rk9.rao.ui.notification.RealTimeSubscriberManager;
@@ -490,56 +492,61 @@ public class GraphView extends JFrame implements GraphApi {
 
 	private final void updateInfo(mxCell cell) {
 		Node node = (Node) cell.getValue();
-		String cellInfo = getCellInfo(node);
+		List<InfoElement> cellInfoList = getCellInfo(node);
 		PlatformUI.getWorkbench().getDisplay().syncExec(() -> {
 			if (graphInfoWindow == null || graphInfoWindow.isDisposed())
 				return;
 
-			setCellInfo(cellInfo);
+			setCellInfo(cellInfoList);
 			setGraphInfo();
 		});
 	}
 
-	private final String getCellInfo(Node node) {
-		String cellInfo = "";
-		cellInfo += "Node number: " + String.valueOf(node.index) + "\n";
+	private final List<InfoElement> getCellInfo(Node node) {
+		List<InfoElement> cellInfoList = new ArrayList<InfoElement>();
 
-		String parentName = "Root";
-		if (node.parent != null) {
-			parentName = "Parent node number: "
-					+ String.valueOf(node.parent.index);
-		}
-		parentName += "\n";
+		cellInfoList.add(new InfoElement("Node number", String
+				.valueOf(node.index)));
+		cellInfoList.add(new InfoElement("Parent number",
+				node.parent == null ? "" : String.valueOf(node.parent.index)));
+		cellInfoList.add(new InfoElement("Current path cost (g)", String
+				.valueOf(node.g)));
+		cellInfoList.add(new InfoElement("Remaining path cost (h)", String
+				.valueOf(node.h)));
+		cellInfoList.add(new InfoElement("Full path cost (h)", String
+				.valueOf(node.h + node.g)));
+		cellInfoList.add(new InfoElement("Rule used", node.ruleName));
+		cellInfoList.add(new InfoElement("Relevant resources",
+				node.relevantResources));
+		cellInfoList.add(new InfoElement("Rule cost", String
+				.valueOf(node.ruleCost)));
 
-		cellInfo += parentName;
-		cellInfo += "Path cost (g) = " + Double.toString(node.g) + "\n";
-		cellInfo += "Remaining path cost (h) = " + Double.toString(node.h)
-				+ "\n";
-		cellInfo += node.ruleDesсription + "\n";
-		cellInfo += "Rule cost = " + Double.toString(node.ruleCost);
-
-		return cellInfo;
+		return cellInfoList;
 	}
 
-	private final String getGraphInfo() {
+	private final List<InfoElement> getGraphInfo() {
+		List<InfoElement> graphInfoList = new ArrayList<InfoElement>();
 		GraphInfo info = treeBuilder.graphInfo;
-		String graphInfo = "";
-		graphInfo += "Solution cost: " + String.valueOf(info.solutionCost)
-				+ "\n";
-		graphInfo += "Nodes opened: " + String.valueOf(info.numOpened) + "\n";
-		graphInfo += "Nodes total: " + String.valueOf(info.numNodes) + "\n";
-		graphInfo += "Max depth: " + String.valueOf(info.depth) + "\n";
-		graphInfo += "Max width: " + String.valueOf(info.width);
 
-		return graphInfo;
+		graphInfoList.add(new InfoElement("Solution cost", String
+				.valueOf(info.solutionCost)));
+		graphInfoList.add(new InfoElement("Nodes opened", String
+				.valueOf(info.numOpened)));
+		graphInfoList.add(new InfoElement("Nodes total", String
+				.valueOf(info.numNodes)));
+		graphInfoList.add(new InfoElement("Max depth", String
+				.valueOf(info.depth)));
+		graphInfoList.add(new InfoElement("Max width", String
+				.valueOf(info.width)));
+
+		return graphInfoList;
 	}
 
-	private final void setCellInfo(String cellInfo) {
+	private final void setCellInfo(List<InfoElement> cellInfo) {
 		if (graphInfoWindow == null || graphInfoWindow.isDisposed())
 			return;
 
-		graphInfoWindow.getCellInfoLabel().setText(cellInfo);
-		graphInfoWindow.updateContents();
+		graphInfoWindow.setCellInfoInput(cellInfo);
 	}
 
 	private final void setGraphInfo() {
@@ -549,8 +556,7 @@ public class GraphView extends JFrame implements GraphApi {
 		if (graphInfoWindow == null || graphInfoWindow.isDisposed())
 			return;
 
-		graphInfoWindow.getGraphInfoLabel().setText(getGraphInfo());
-		graphInfoWindow.updateContents();
+		graphInfoWindow.setGraphInfoInput(getGraphInfo());
 	}
 
 	// ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― //
@@ -656,7 +662,7 @@ public class GraphView extends JFrame implements GraphApi {
 		final String number = Integer.toString(node.index);
 		final String costFunction = Double.toString(node.g + node.h) + " = "
 				+ Double.toString(node.g) + " + " + Double.toString(node.h);
-		final String rule = node.ruleDesсription + " = "
+		final String rule = node.ruleName + " = "
 				+ Double.toString(node.ruleCost);
 		final String shortRule = rule.replaceAll("\\(.*\\)", "");
 
@@ -722,7 +728,7 @@ public class GraphView extends JFrame implements GraphApi {
 				final String costFunction = Double.toString(node.g + node.h)
 						+ " = " + Double.toString(node.g) + " + "
 						+ Double.toString(node.h);
-				final String rule = node.ruleDesсription + " = "
+				final String rule = node.ruleName + " = "
 						+ Double.toString(node.ruleCost);
 				final String shortRule = rule.replaceAll("\\(.*\\)", "");
 				final String text = number + "\n" + costFunction + "\n"

--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/TreeBuilder.java
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/graph/TreeBuilder.java
@@ -51,8 +51,10 @@ public class TreeBuilder {
 		public double g;
 		public double h;
 		public int ruleNumber;
-		public String ruleDesсription;
+		public String ruleName;
 		public double ruleCost;
+		public String relevantResources;
+
 		public String label;
 
 		@Override
@@ -135,7 +137,7 @@ public class TreeBuilder {
 						.get(patternNumber).getRelResTypes().size();
 
 				StringJoiner relResStringJoiner = new StringJoiner(
-						StringFormat.FUNCTION);
+						StringFormat.ENUMERATION);
 
 				for (int num = 0; num < numberOfRelevantResources; num++) {
 					final int resNum = data.getInt();
@@ -159,8 +161,8 @@ public class TreeBuilder {
 				treeNode.g = g;
 				treeNode.h = h;
 				treeNode.ruleNumber = ruleNum;
-				treeNode.ruleDesсription = activity.getName()
-						+ relResStringJoiner.getString();
+				treeNode.ruleName = activity.getName();
+				treeNode.relevantResources = relResStringJoiner.getString();
 				treeNode.ruleCost = ruleCost;
 
 				treeNode.depthLevel = treeNode.parent.depthLevel + 1;

--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/plot/PlotView.java
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/plot/PlotView.java
@@ -8,8 +8,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.eclipse.jdt.ui.PreferenceConstants;
-import org.eclipse.jface.resource.FontRegistry;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.DisposeEvent;
 import org.eclipse.swt.events.DisposeListener;
@@ -39,8 +37,8 @@ import ru.bmstu.rk9.rao.lib.database.CollectedDataNode.PatternIndex;
 import ru.bmstu.rk9.rao.lib.database.CollectedDataNode.ResultIndex;
 import ru.bmstu.rk9.rao.lib.database.Database.ResultType;
 import ru.bmstu.rk9.rao.lib.notification.Subscriber;
-import ru.bmstu.rk9.rao.lib.simulator.SimulatorSubscriberManager;
 import ru.bmstu.rk9.rao.lib.simulator.Simulator.ExecutionState;
+import ru.bmstu.rk9.rao.lib.simulator.SimulatorSubscriberManager;
 import ru.bmstu.rk9.rao.lib.simulator.SimulatorSubscriberManager.SimulatorSubscriberInfo;
 import ru.bmstu.rk9.rao.ui.notification.RealTimeSubscriberManager;
 import ru.bmstu.rk9.rao.ui.plot.PlotDataParser.PlotItem;

--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/serialization/SerializedObjectsView.java
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/serialization/SerializedObjectsView.java
@@ -42,7 +42,7 @@ import ru.bmstu.rk9.rao.lib.simulator.Simulator;
 import ru.bmstu.rk9.rao.lib.simulator.SimulatorSubscriberManager;
 import ru.bmstu.rk9.rao.lib.simulator.Simulator.ExecutionState;
 import ru.bmstu.rk9.rao.lib.simulator.SimulatorSubscriberManager.SimulatorSubscriberInfo;
-import ru.bmstu.rk9.rao.ui.graph.GraphView;
+import ru.bmstu.rk9.rao.ui.graph.GraphPanel;
 import ru.bmstu.rk9.rao.ui.notification.RealTimeSubscriberManager;
 import ru.bmstu.rk9.rao.ui.plot.PlotView;
 
@@ -102,7 +102,7 @@ public class SerializedObjectsView extends ViewPart {
 		serializedObjectsTree.setMenu(popupMenu);
 		conditionalMenuItems.add(PlotView.createConditionalMenuItem(popupMenu));
 		conditionalMenuItems
-				.add(GraphView.createConditionalMenuItem(popupMenu));
+				.add(GraphPanel.createConditionalMenuItem(popupMenu));
 		serializedObjectsTreeViewer.getTree().setMenu(popupMenu);
 
 		serializedObjectsTreeViewer

--- a/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/compilers/DecisionPointCompiler.xtend
+++ b/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/compilers/DecisionPointCompiler.xtend
@@ -132,7 +132,7 @@ class DecisionPointCompiler
 										executed
 									);
 
-									executed.addResourceEntriesToDatabase(null);
+									executed.addResourceEntriesToDatabase(null, null);
 
 									return executed;
 								}

--- a/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/compilers/EventCompiler.xtend
+++ b/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/compilers/EventCompiler.xtend
@@ -70,7 +70,7 @@ class EventCompiler
 				db.addEventEntry(this);
 				db.addMemorizedResourceEntries(
 						"«event.fullyQualifiedName».createdResources",
-						null);
+						null, null);
 			}
 
 			public «event.name»(double time«IF !event.parameters.empty», «ENDIF»«event.parameters.compileParameterTypes»)

--- a/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/compilers/ModelCompiler.xtend
+++ b/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/compilers/ModelCompiler.xtend
@@ -67,7 +67,7 @@ class ModelCompiler
 							«ENDIF»
 					«ENDFOR»
 				«ENDFOR»
-				db.addMemorizedResourceEntries(null, null);
+				db.addMemorizedResourceEntries(null, null, null);
 			}
 
 			public static «project»Model getCurrent()

--- a/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/compilers/PatternCompiler.xtend
+++ b/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/compilers/PatternCompiler.xtend
@@ -192,7 +192,7 @@ class PatternCompiler
 				db.addOperationEndEntry(this);
 				db.addMemorizedResourceEntries(
 						"«operation.fullyQualifiedName»",
-						null);
+						null, null);
 			}
 
 			public static final JSONObject structure = new JSONObject()
@@ -414,12 +414,13 @@ class PatternCompiler
 			}
 
 			@Override
-			public void addResourceEntriesToDatabase(Pattern.ExecutedFrom executedFrom)
+			public void addResourceEntriesToDatabase(Pattern.ExecutedFrom executedFrom, String dptName)
 			{
 				Database db = Simulator.getDatabase();
 				db.addMemorizedResourceEntries(
 						"«pattern.fullyQualifiedName».createdResources",
-						executedFrom);
+						executedFrom,
+						dptName);
 			}
 
 			@Override


### PR DESCRIPTION
- граф помещен в `swt-shell`
- окошко всегда поверх окна с графом
- окошко имеет фиксированный размер, если текст в поле не вмещается, то появляется всплывающая подсказка с полным текстом (тестил под виндой)

Надо еще немного почистить код (много проблем было вызвано этим багом эклипса: http://stackoverflow.com/questions/15971480/jface-columnweigthdata-causes-parent-to-grow, https://bugs.eclipse.org/bugs/show_bug.cgi?id=215997#c4) и поправить пятнашки, т.к. совместимость я сломал.
