### PR TITLE
Окно с предложением смены перспективы.

### DIFF
--- a/ru.bmstu.rk9.rao.ui/plugin.xml
+++ b/ru.bmstu.rk9.rao.ui/plugin.xml
@@ -1031,7 +1031,8 @@
             id="ru.bmstu.rk9.rao.ui.wizard.RaoWizard"
             icon="icons/rao_old.gif"
             category="ru.bmstu.rk9.rao.wizard"
-            project="true">
+            project="true"
+            finalPerspective="ru.bmstu.rk9.rao.ui.perspective">
       </wizard>
   </extension>
 

--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/wizard/RaoWizard.java
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/wizard/RaoWizard.java
@@ -12,7 +12,7 @@ import ru.bmstu.rk9.rao.ui.wizard.ProjectConfigurator.ProjectWizardStatus;
 public class RaoWizard extends BasicNewProjectResourceWizard implements IWorkbenchWizard, IExecutableExtension {
 
 	protected RaoWizardPage wizardPage;
-	private IConfigurationElement configElement;
+	private IConfigurationElement configurationElement;
 
 	@Override
 	public void addPages() {
@@ -26,7 +26,7 @@ public class RaoWizard extends BasicNewProjectResourceWizard implements IWorkben
 		final ProjectWizardStatus projectWizardStatus = new ProjectConfigurator(info).initializeProject();
 		switch (projectWizardStatus) {
 		case SUCCESS:
-			updatePerspective(configElement);
+			updatePerspective(configurationElement);
 			return true;
 		case UNDEFINED_ERROR:
 			return false;
@@ -45,7 +45,7 @@ public class RaoWizard extends BasicNewProjectResourceWizard implements IWorkben
 	}
 
 	@Override
-	public void setInitializationData(IConfigurationElement cfig, String propertyName, Object data) {
-		configElement = cfig;
+	public void setInitializationData(IConfigurationElement configurationElement, String propertyName, Object data) {
+		this.configurationElement = configurationElement;
 	}
 }

--- a/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/wizard/RaoWizard.java
+++ b/ru.bmstu.rk9.rao.ui/src/ru/bmstu/rk9/rao/ui/wizard/RaoWizard.java
@@ -1,15 +1,18 @@
 package ru.bmstu.rk9.rao.ui.wizard;
 
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IExecutableExtension;
 import org.eclipse.jface.viewers.IStructuredSelection;
-import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchWizard;
+import org.eclipse.ui.wizards.newresource.BasicNewProjectResourceWizard;
 
 import ru.bmstu.rk9.rao.ui.wizard.ProjectConfigurator.ProjectWizardStatus;
 
-public class RaoWizard extends Wizard implements IWorkbenchWizard {
+public class RaoWizard extends BasicNewProjectResourceWizard implements IWorkbenchWizard, IExecutableExtension {
 
 	protected RaoWizardPage wizardPage;
+	private IConfigurationElement configElement;
 
 	@Override
 	public void addPages() {
@@ -19,12 +22,11 @@ public class RaoWizard extends Wizard implements IWorkbenchWizard {
 
 	@Override
 	public boolean performFinish() {
-		final ProjectInfo info = new ProjectInfo(wizardPage.getProjectName(),
-				wizardPage.getTemplate());
-		final ProjectWizardStatus projectWizardStatus = new ProjectConfigurator(
-				info).initializeProject();
+		final ProjectInfo info = new ProjectInfo(wizardPage.getProjectName(), wizardPage.getTemplate());
+		final ProjectWizardStatus projectWizardStatus = new ProjectConfigurator(info).initializeProject();
 		switch (projectWizardStatus) {
 		case SUCCESS:
+			updatePerspective(configElement);
 			return true;
 		case UNDEFINED_ERROR:
 			return false;
@@ -40,5 +42,10 @@ public class RaoWizard extends Wizard implements IWorkbenchWizard {
 	@Override
 	public String getWindowTitle() {
 		return "New Rao Project";
+	}
+
+	@Override
+	public void setInitializationData(IConfigurationElement cfig, String propertyName, Object data) {
+		configElement = cfig;
 	}
 }


### PR DESCRIPTION
При создании Rao-проекта не из перспективы Rao, выпадает стандартное эклипсовское окно
с предложением перейти на упомянутую перспективу (как при создании проекта Java и пр).
- Переписал RaoWizard под родителя BasicNewProjectResourceWizard для
  использования его методов и атрибутов.
- Добавил в описание RaoWizard в plugin.xml id-шник предлагаемой
  перспективы.

Все ответы на вопросы о non-API либах нашел в исходниках Eclipse CDT, предупреждения вычистил.
(aurusov/rdo-xtext#207)
