### PR TITLE
Исправление ошибок в реализации А*

### DIFF
--- a/ru.bmstu.rk9.rao.lib/src/ru/bmstu/rk9/rao/lib/dpt/DecisionPointSearch.java
+++ b/ru.bmstu.rk9.rao.lib/src/ru/bmstu/rk9/rao/lib/dpt/DecisionPointSearch.java
@@ -177,11 +177,7 @@ public class DecisionPointSearch<T extends ModelState<T>> extends DecisionPoint 
 
 		head = new GraphNode(totalAdded++, null);
 		head.state = retriever.get();
-		nodesClosed.add(head);
-
-		head.children = spawnChildren(head);
-
-		nodesOpen.addAll(head.children);
+		nodesOpen.add(head);
 
 		while (!nodesOpen.isEmpty()) {
 			if (!allowSearch)

--- a/ru.bmstu.rk9.rao.lib/src/ru/bmstu/rk9/rao/lib/dpt/DecisionPointSearch.java
+++ b/ru.bmstu.rk9.rao.lib/src/ru/bmstu/rk9/rao/lib/dpt/DecisionPointSearch.java
@@ -190,18 +190,11 @@ public class DecisionPointSearch<T extends ModelState<T>> extends DecisionPoint 
 			totalOpened++;
 			serializeOpen(current);
 
+			if (terminate.check())
+				return stop(StopCode.SUCCESS);
+
 			current.children = spawnChildren(current);
 			nodesOpen.addAll(current.children);
-
-			for (GraphNode child : current.children) {
-				child.state.deploy();
-				if (terminate.check()) {
-					current = child;
-					return stop(StopCode.SUCCESS);
-				}
-
-				current.state.deploy();
-			}
 		}
 
 		head.state.deploy();

--- a/ru.bmstu.rk9.rao.lib/src/ru/bmstu/rk9/rao/lib/dpt/DecisionPointSearch.java
+++ b/ru.bmstu.rk9.rao.lib/src/ru/bmstu/rk9/rao/lib/dpt/DecisionPointSearch.java
@@ -238,10 +238,10 @@ public class DecisionPointSearch<T extends ModelState<T>> extends DecisionPoint 
 			add_child: {
 				compare_tops: if (compareTops) {
 					for (Collection<GraphNode> nodesList : Arrays.asList(nodesOpen, nodesClosed)) {
-						for (GraphNode open : nodesList) {
-							if (newChild.state.checkEqual(open.state)) {
-								if (newChild.g < open.g) {
-									nodesList.remove(open);
+						for (GraphNode node : nodesList) {
+							if (newChild.state.checkEqual(node.state)) {
+								if (newChild.g < node.g) {
+									nodesList.remove(node);
 									spawnStatus = SpawnStatus.BETTER;
 									break compare_tops;
 								} else {


### PR DESCRIPTION
- корневая вершина помещается в список открытых вершин при старте алгоритме и далее никак специально не обрабатывается
- откатил https://github.com/aurusov/rdo-xtext/commit/2fc88bfdd2413a65b12ad41cf151b49930346841 (почему - объяснил в соответствующей таске (aurusov/rdo-xtext#263) и в сообщении к коммиту)
- порефакторил код поиска для лучшей читаемости

Для злосчатностной ситуации

``` erlang
resource Фишка1 = Фишка.create(1, 2);
resource Фишка2 = Фишка.create(2, 5);
resource Фишка3 = Фишка.create(3, 3);
resource Фишка4 = Фишка.create(4, 1);
resource Фишка5 = Фишка.create(5, 6);
resource Дырка = Дырка_t.create(4);
```

Решение теперь выглядит так:
![dpt_search_fixed](https://cloud.githubusercontent.com/assets/6528492/11149955/605a2654-8a36-11e5-9d71-7333acebdea4.png)

До этого было так:
![priority](https://cloud.githubusercontent.com/assets/6528492/10870131/0c1d5e8c-80d4-11e5-9838-e7b37bcf96c7.png)
