### PR TITLE
Исправлен рефкаунтинг для свойства ресурсов `accessible`

### DIFF
--- a/ru.bmstu.rk9.rao.lib/src/ru/bmstu/rk9/rao/lib/process/Release.java
+++ b/ru.bmstu.rk9.rao.lib/src/ru/bmstu/rk9/rao/lib/process/Release.java
@@ -44,7 +44,7 @@ public class Release implements Block {
 		CurrentSimulator.getDatabase().addProcessEntry(ProcessEntryType.RELEASE, transact.getNumber(), data);
 
 		transactStorage.pushTransact(transact);
-		resource.setAccessible(true);
+		resource.put();
 		return BlockStatus.SUCCESS;
 	}
 }

--- a/ru.bmstu.rk9.rao.lib/src/ru/bmstu/rk9/rao/lib/process/Seize.java
+++ b/ru.bmstu.rk9.rao.lib/src/ru/bmstu/rk9/rao/lib/process/Seize.java
@@ -43,7 +43,7 @@ public class Seize implements Block {
 		data.putInt(resourceTypeNumber).putInt(resource.getNumber());
 		CurrentSimulator.getDatabase().addProcessEntry(ProcessEntryType.SEIZE, transact.getNumber(), data);
 		transactStorage.pushTransact(transact);
-		resource.setAccessible(false);
+		resource.take();
 		return BlockStatus.SUCCESS;
 	}
 }

--- a/ru.bmstu.rk9.rao.lib/src/ru/bmstu/rk9/rao/lib/resource/Resource.java
+++ b/ru.bmstu.rk9.rao.lib/src/ru/bmstu/rk9/rao/lib/resource/Resource.java
@@ -22,15 +22,19 @@ public abstract class Resource extends RaoNameable implements Serializable {
 
 	protected Integer number = null;
 
-	public final void setAccessible(boolean accessible) {
-		this.accessible = accessible;
+	public final void take() {
+		refcounter++;
+	}
+
+	public final void put() {
+		refcounter--;
 	}
 
 	public final boolean isAccessible() {
-		return accessible;
+		return refcounter == 0;
 	}
 
-	protected boolean accessible = true;
+	protected int refcounter = 0;
 
 	public final boolean isShallowCopy() {
 		return isShallowCopy;

--- a/ru.bmstu.rk9.rao.rcptt/tests/model_accessible_all_conflict/accessible_all_conflict.rao.template
+++ b/ru.bmstu.rk9.rao.rcptt/tests/model_accessible_all_conflict/accessible_all_conflict.rao.template
@@ -1,0 +1,34 @@
+type Y {
+	int a
+}
+
+resource y1 = Y.create(0)
+
+operation Op1() {
+	relevant xx = Y.accessible.filter[a < 20].any
+
+	set duration() {
+		return 20;
+	}
+
+	set begin() {
+		xx.a = xx.a + 1
+	}
+
+	set end() {
+		xx.a = xx.a + 10
+	}
+}
+
+operation Op2() {
+	relevant xx = Y.all.filter[a < 2].any
+
+	set begin() {
+		xx.a = xx.a + 1
+	}
+}
+
+logic L {
+	activity a = new Activity(Op1.create())
+	activity b = new Activity(Op2.create())
+}

--- a/ru.bmstu.rk9.rao.rcptt/tests/model_accessible_all_conflict/accessible_all_conflict.trc.etalon
+++ b/ru.bmstu.rk9.rao.rcptt/tests/model_accessible_all_conflict/accessible_all_conflict.trc.etalon
@@ -1,0 +1,15 @@
+ES 0.0 Tracing started
+RC 0.0 y1 = {0}
+ES 0.0 Simulation started
+EB 0.0 a[0](y1)
+RK 0.0 y1 = {1}
+EB 0.0 b[0](y1)
+RK 0.0 y1 = {2}
+EF 0.0 b[0](y1)
+EF 20.0 a[0](y1)
+RK 20.0 y1 = {12}
+EB 20.0 a[1](y1)
+RK 20.0 y1 = {13}
+EF 40.0 a[1](y1)
+RK 40.0 y1 = {23}
+ES 40.0 Simulation finished: no more events

--- a/ru.bmstu.rk9.rao.rcptt/tests/model_accessible_all_conflict/model_accessible_all_conflict.test
+++ b/ru.bmstu.rk9.rao.rcptt/tests/model_accessible_all_conflict/model_accessible_all_conflict.test
@@ -1,0 +1,18 @@
+--- RCPTT testcase ---
+Format-Version: 1.0
+Contexts: _4tzl0IraEeaeL56tcQCn5g
+Element-Name: model_accessible_all_conflict
+Element-Type: testcase
+Element-Version: 3.0
+External-Reference: 
+Id: _sFPi0IraEeaeL56tcQCn5g
+Runtime-Version: 2.0.1.201508250612
+Save-Time: 10/5/16 12:06 PM
+Testcase-Type: ecl
+
+------=_.content-0a7243a0-75d3-3d5f-9791-539de0e5b7ac
+Content-Type: text/ecl
+Entry-Name: .content
+
+test_model_source_trace "accessible_all_conflict"
+------=_.content-0a7243a0-75d3-3d5f-9791-539de0e5b7ac--

--- a/ru.bmstu.rk9.rao.rcptt/tests/model_accessible_all_conflict/model_accessible_all_conflict_notrace.test
+++ b/ru.bmstu.rk9.rao.rcptt/tests/model_accessible_all_conflict/model_accessible_all_conflict_notrace.test
@@ -1,0 +1,19 @@
+--- RCPTT testcase ---
+Format-Version: 1.0
+Contexts: _4tzl0IraEeaeL56tcQCn5g
+Element-Name: model_accessible_all_conflict_notrace
+Element-Type: testcase
+Element-Version: 3.0
+External-Reference: 
+Id: _zrMnkIraEeaeL56tcQCn5g
+Runtime-Version: 2.0.1.201508250612
+Save-Time: 10/5/16 12:06 PM
+Testcase-Type: ecl
+
+------=_.content-0a7243a0-75d3-3d5f-9791-539de0e5b7ac
+Content-Type: text/ecl
+Entry-Name: .content
+
+test_model_source_notrace "accessible_all_conflict"
+
+------=_.content-0a7243a0-75d3-3d5f-9791-539de0e5b7ac--

--- a/ru.bmstu.rk9.rao.rcptt/tests/model_accessible_all_conflict/model_accessible_all_conflict_prepare.ctx
+++ b/ru.bmstu.rk9.rao.rcptt/tests/model_accessible_all_conflict/model_accessible_all_conflict_prepare.ctx
@@ -1,0 +1,23 @@
+--- RCPTT testcase ---
+Format-Version: 1.0
+Context-Type: org.eclipse.rcptt.ctx.workspace
+Element-Name: model_accessible_all_conflict_prepare
+Element-Type: context
+Element-Version: 2.0
+Id: _4tzl0IraEeaeL56tcQCn5g
+Runtime-Version: 2.0.1.201508250612
+Save-Time: 10/5/16 12:06 PM
+
+------=_.q7.content-3d2e0690-ce48-3609-83e0-c704d49f1eaf
+Content-Type: q7/binary
+Entry-Name: .q7.content
+
+UEsDBBQACAgIAAAAIQAAAAAAAAAAAAAAAAAIAAkALmNvbnRlbnRVVAUAAQAAAAC9kj1PwzAQhvf+isg7
+NiCKIEraoWKoVAYm2CL3ek1N/SX7SiJ+PU5IIhY+urCdfc/d+57PxbI1OnvDEJWzJbvilyxDC26nbF2y
+E+0v7thyMStcqDmCVj4iD+CJOFDLGxeO0UvA/HmMVs4StpS1RuVT2+uubRKyMU/3JTsQ+VyIpmm4MzVP
+zcXL43pEftGaykemK+85kTgxcSyz0iTauB3qSgJgjGqrsZJaV+DsXiugygf0MiRY7UpW3dC7vlwH+YAS
+N/NbgqeVnddsMcuyArrJLHVxOvngXhEoDiJIUjvLPpMpvVcaN8oex/w38jxIxwmN15KSh6FpycKJbw3F
+Ew/H+57p50uApEPJCCNF8eNc4k+C4my/FIAPs/6H2y9yg9dCjC/fL0VMWynEuX90MfsAUEsHCPXJBsMw
+AQAA/gIAAFBLAQIUABQACAgIAAAAIQD1yQbDMAEAAP4CAAAIAAkAAAAAAAAAAAAAAAAAAAAuY29udGVu
+dFVUBQABAAAAAFBLBQYAAAAAAQABAD8AAABvAQAAAAA=
+------=_.q7.content-3d2e0690-ce48-3609-83e0-c704d49f1eaf--

--- a/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/jvmmodel/PatternCompiler.xtend
+++ b/ru.bmstu.rk9.rao/src/ru/bmstu/rk9/rao/jvmmodel/PatternCompiler.xtend
@@ -156,7 +156,7 @@ class PatternCompiler extends RaoEntityCompiler {
 								finish();
 								return false;
 							}
-							this.«relevant.name».setAccessible(false);
+							this.«relevant.name».take();
 							this.relevantResourcesNumbers.add(this.«relevant.name».getNumber());
 						«ENDFOR»
 						«FOR tuple : pattern.relevantTuples»«
@@ -169,7 +169,7 @@ class PatternCompiler extends RaoEntityCompiler {
 							} else {
 								«FOR name : tuple.names»
 									this.«name» = __«tupleInfo.name».«tupleInfo.tupleElementsInfo.get(tuple.names.indexOf(name)).name»;
-									this.«name».setAccessible(false);
+									this.«name».take();
 									this.relevantResourcesNumbers.add(this.«name».getNumber());
 								«ENDFOR»
 							}
@@ -186,12 +186,12 @@ class PatternCompiler extends RaoEntityCompiler {
 					body = '''
 						«FOR relevant : pattern.relevantResources»
 							if (this.«relevant.name» != null)
-								this.«relevant.name».setAccessible(true);
+								this.«relevant.name».put();
 						«ENDFOR»
 						«FOR tuple : pattern.relevantTuples»
 							«FOR name : tuple.names»
 								if (this.«name» != null)
-									this.«name».setAccessible(true);
+									this.«name».put();
 							«ENDFOR»
 						«ENDFOR»
 					'''


### PR DESCRIPTION
До этого был возможен следующий сценарий:
1. Паттерн 1 захватывает ресурсы через `accessible`, выставляет ресурсам `accessible` = `false`
2. Паттерн 2 захватывает ресурсы через `all`, повторно выставляет ресурсам `accessible` = `false`
3. Паттерн 2 отпускает ресурсы, и теперь выставляет ресурсам `accessible` = `true`
4. Паттерн 1 теперь снова может захватить ресурсы, несмотря на то, что он их еще не отпускал

Чтобы решить эту проблему, теперь вместо обычного `boolean` для проверки на `accessible` используется рефкаунтинг.

Когда дооформлю тест с этим сценарием, добавлю его в пул-реквест тоже.
